### PR TITLE
Background Service: Add Wifi-only option

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampus/auxiliary/NetUtils.java
+++ b/app/src/main/java/de/tum/in/tumcampus/auxiliary/NetUtils.java
@@ -92,6 +92,20 @@ public class NetUtils {
     }
 
     /**
+     * Check if a network connection is available or can be available soon
+     * and if the available connection is a wifi internet connection
+     *
+     * @return true if available
+     */
+    public static boolean isConnectedWifi(Context con) {
+        ConnectivityManager cm = (ConnectivityManager) con
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo netInfo = cm.getActiveNetworkInfo();
+
+        return netInfo != null && netInfo.isConnectedOrConnecting() && netInfo.getType() == ConnectivityManager.TYPE_WIFI;
+    }
+
+    /**
      * Gets an unique id that identifies this device
      *
      * @return Unique device id

--- a/app/src/main/java/de/tum/in/tumcampus/fragments/SettingsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampus/fragments/SettingsFragment.java
@@ -82,6 +82,7 @@ public class SettingsFragment extends PreferenceFragment implements
         setSummary("card_stations_default_K");
         setSummary("card_default_campus");
         setSummary("silent_mode_set_to");
+        setSummary("background_mode_set_to");
 
         // Register the change listener to react immediately on changes
         PreferenceManager.getDefaultSharedPreferences(mContext)

--- a/app/src/main/java/de/tum/in/tumcampus/services/StartSyncReceiver.java
+++ b/app/src/main/java/de/tum/in/tumcampus/services/StartSyncReceiver.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 
 import de.tum.in.tumcampus.auxiliary.Const;
+import de.tum.in.tumcampus.auxiliary.NetUtils;
 import de.tum.in.tumcampus.auxiliary.Utils;
 
 /**
@@ -21,13 +22,15 @@ public class StartSyncReceiver extends BroadcastReceiver {
         // check intent if called from StartupActivity
         final boolean launch = intent.getBooleanExtra(Const.APP_LAUNCHES, false);
 
+        // Look up background service settings
+        final boolean backgroundServicePermitted = isBackgroundServicePermitted(context);
+
         // Set Alarm for next update, if background service is enabled
-        final boolean backgroundServiceEnabled = Utils.getSettingBool(context, Const.BACKGROUND_MODE, false);
-        if(backgroundServiceEnabled)
+        if(backgroundServicePermitted)
             setAlarm(context);
 
         // Start BackgroundService
-        if (launch || backgroundServiceEnabled) {
+        if (launch || backgroundServicePermitted) {
             Utils.logv("Start background service...");
             Intent i = new Intent(context, BackgroundService.class);
             i.putExtra(Const.APP_LAUNCHES,launch);
@@ -35,6 +38,18 @@ public class StartSyncReceiver extends BroadcastReceiver {
         }
 
         context.startService(new Intent(context, SendMessageService.class));
+    }
+
+    private boolean isBackgroundServicePermitted(Context context) {
+        return isBackgroundServiceEnabled(context) && (isBackgroundServiceAlwaysEnabled(context) || NetUtils.isConnectedWifi(context));
+    }
+
+    private boolean isBackgroundServiceEnabled(Context context) {
+        return Utils.getSettingBool(context, Const.BACKGROUND_MODE, false);
+    }
+
+    private boolean isBackgroundServiceAlwaysEnabled(Context context) {
+        return Utils.getSetting(context, "background_mode_set_to", "0").equals("0");
     }
 
     private void setAlarm(Context context) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -75,6 +75,9 @@
     <string name="silence_phone_info">Das Gerät wird während einer Vorlesung automatisch in den lautlosen Modus gestellt.</string>
     <string name="background_mode">Hintergrund Modus (Empfohlen)</string>
     <string name="background_info">Aktualisiert die Inhalte der App einmal täglich, um dich auf dem neusten Stand zu halten, sogar wenn die App nicht geöffnet ist.</string>
+    <string name="mode_background_mode">Aktivierung des Hintergrund Modus</string>
+    <string name="always">Immer</string>
+    <string name="wifi_only">Nur mit WLAN-Verbindung</string>
     <string name="demo_mode">In-App-Tutorial</string>
     <string name="demo_info">Hilfemodus aktivieren, um Informationen zur Bedienung der App zu erhalten.</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -77,7 +77,7 @@
     <string name="background_info">Aktualisiert die Inhalte der App einmal täglich, um dich auf dem neusten Stand zu halten, sogar wenn die App nicht geöffnet ist.</string>
     <string name="mode_background_mode">Aktivierung des Hintergrund Modus</string>
     <string name="always">Immer</string>
-    <string name="wifi_only">Nur mit WLAN-Verbindung</string>
+    <string name="wifi_only">Nur bei WLAN-Verbindung</string>
     <string name="demo_mode">In-App-Tutorial</string>
     <string name="demo_info">Hilfemodus aktivieren, um Informationen zur Bedienung der App zu erhalten.</string>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -88,6 +88,14 @@
         <item>0</item>
         <item>1</item>
     </string-array>
+    <string-array name="background_entries">
+        <item>@string/always</item>
+        <item>@string/wifi_only</item>
+    </string-array>
+    <string-array name="background_mode_values" tools:ignore="MissingTranslation">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
     <string-array name="default_campus_entries">
         <item>@string/no_default_campus</item>
         <item>@string/campus_garching</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,9 @@
     <string name="silence_phone_info">The device will be automatically put into silent mode during a lecture.</string>
     <string name="background_mode">Background Mode (Recommended)</string>
     <string name="background_info">Content will be fetched once per day to keep you up-to-date even if you don\'t open the app.</string>
+    <string name="mode_background_mode">Background Mode activation</string>
+    <string name="always">Always</string>
+    <string name="wifi_only">WiFi only</string>
     <string name="demo_mode">In-App-Tutorial</string>
     <string name="demo_info">Activates help mode for instruction on how to use this App.</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -279,6 +279,13 @@
             android:key="background_mode"
             android:summary="@string/background_info"
             android:title="@string/background_mode" />
+        <ListPreference
+            android:defaultValue="0"
+            android:dependency="background_mode"
+            android:entries="@array/background_entries"
+            android:entryValues="@array/background_mode_values"
+            android:key="background_mode_set_to"
+            android:title="@string/mode_background_mode" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/extras">
         <Preference


### PR DESCRIPTION
Users can choose via settings menu if they want the background service download to start always or only when connected to a wifi network. (see #284)

It seems to work, but I haven't tested it properly atm.