### PR TITLE
Use an AlarmManager with SilenceService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,9 @@
     <!-- For QR code scanner -->
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <!-- To start the SilenceService when the device boots -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <!--
      Creates a custom permission so only this app can receive its messages.
 
@@ -95,6 +98,13 @@
                 <action android:name="android.net.wifi.STATE_CHANGED"/>
                 <action android:name="android.net.wifi.WIFI_STATE_CHANGED"/>-->
                 <action android:name="android.net.wifi.SCAN_RESULTS" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Start the SilenceService on boot completed -->
+        <receiver android:name=".services.SilenceService$SilenceServiceBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,9 +43,6 @@
     <!-- For QR code scanner -->
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- To start the SilenceService when the device boots -->
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-
     <!--
      Creates a custom permission so only this app can receive its messages.
 
@@ -98,13 +95,6 @@
                 <action android:name="android.net.wifi.STATE_CHANGED"/>
                 <action android:name="android.net.wifi.WIFI_STATE_CHANGED"/>-->
                 <action android:name="android.net.wifi.SCAN_RESULTS" />
-            </intent-filter>
-        </receiver>
-
-        <!-- Start the SilenceService on boot completed -->
-        <receiver android:name=".services.SilenceService$SilenceServiceBroadcastReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/de/tum/in/tumcampus/auxiliary/Const.java
+++ b/app/src/main/java/de/tum/in/tumcampus/auxiliary/Const.java
@@ -44,6 +44,8 @@ public final class Const {
     public static final String URL_COLUMN = "url";
 	public static final String SILENCE_ON = "silence_on";
 	public static final String SILENCE_SERVICE = "silent_mode";
+	public static final String SILENCE_OLD_STATE = "silence_old_state";
+	public static final String SILENT_MODE_SET_TO = "silent_mode_set_to";
 	public static final String TITLE_EXTRA = "title";
 	public static final String TRANSPORT_COLUMN = "transport";
 	public static final String WARNING = "warning";

--- a/app/src/main/java/de/tum/in/tumcampus/services/SilenceService.java
+++ b/app/src/main/java/de/tum/in/tumcampus/services/SilenceService.java
@@ -3,7 +3,6 @@ package de.tum.in.tumcampus.services;
 import android.app.AlarmManager;
 import android.app.IntentService;
 import android.app.PendingIntent;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
@@ -21,13 +20,6 @@ import de.tum.in.tumcampus.models.managers.CalendarManager;
  * Service used to silence the mobile during lectures
  */
 public class SilenceService extends IntentService {
-
-    public static class SilenceServiceBroadcastReceiver extends BroadcastReceiver {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            context.startService(new Intent(context, SilenceService.class));
-        }
-    }
 
     /**
      * Interval in milliseconds to check for current lectures

--- a/app/src/main/java/de/tum/in/tumcampus/services/SilenceService.java
+++ b/app/src/main/java/de/tum/in/tumcampus/services/SilenceService.java
@@ -3,6 +3,7 @@ package de.tum.in.tumcampus.services;
 import android.app.AlarmManager;
 import android.app.IntentService;
 import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
@@ -20,6 +21,13 @@ import de.tum.in.tumcampus.models.managers.CalendarManager;
  * Service used to silence the mobile during lectures
  */
 public class SilenceService extends IntentService {
+
+    public static class SilenceServiceBroadcastReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            context.startService(new Intent(context, SilenceService.class));
+        }
+    }
 
     /**
      * Interval in milliseconds to check for current lectures

--- a/app/src/main/java/de/tum/in/tumcampus/services/StartSyncReceiver.java
+++ b/app/src/main/java/de/tum/in/tumcampus/services/StartSyncReceiver.java
@@ -38,6 +38,9 @@ public class StartSyncReceiver extends BroadcastReceiver {
         }
 
         context.startService(new Intent(context, SendMessageService.class));
+
+        // Also start the SilenceService. It checks if it is enabled, so we don't need to
+        context.startService(new Intent(context, SilenceService.class));
     }
 
     private static boolean isBackgroundServicePermitted(Context context) {


### PR DESCRIPTION
Keeping the SilenceService running to check for lectures wasn't a good idea to begin with.

The current problems are:
* If the TCA is killed, the SilenceService won't work. This is especially a problem on devices with low RAM
* The SilenceService is causing periodic device wakeups, which won't work with [Android Marshmallow's Doze](https://developer.android.com/training/monitoring-device-state/doze-standby.html)
* The TCA needs to keep quite some RAM to be constantely running in background

Switching to AlarmManager fixes those problems and thous should reduce battery drain