### PR TITLE
Enable strict AndroidLint checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ install:
 
 script:
   - ./gradlew build
+
+after_failure:
+  - cat "$TRAVIS_BUILD_DIR/app/build/outputs/lint-results.xml"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,37 @@ android {
         }
     }
     lintOptions {
-        abortOnError false
+        checkAllWarnings true
+        disable "DefaultLocale",
+                "InlinedApi",
+                "NewApi",
+                "SimpleDateFormat",
+                "PrivateResource",
+                "PluralsCandidate",
+                "TrulyRandom",
+                "NestedWeights",
+                "Overdraw",
+                "TypographyQuotes",
+                "IconExpectedSize",
+                "IconLocation",
+                "IconDensities",
+                "ContentDescription",
+                "RelativeOverlap",
+                "InconsistentLayout",
+                "InvalidPackage",
+                "UselessParent",
+                "UnusedResources",    // unused resources get purged by shrinkResources
+                "LogConditional",     // disabeled by default
+                "UnusedIds",          // disabeled by default
+                "SelectableText",     // disabeled by default
+                "RtlCompat",          // we don't support any RTL languages
+                "RtlSymmetry",
+                "RtlHardcoded",
+                "RtlEnabled"
+        htmlReport false
+        warningsAsErrors true
+        abortOnError true
+
     }
 }
 

--- a/app/src/main/java/de/tum/in/tumcampus/activities/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampus/activities/CalendarActivity.java
@@ -140,7 +140,7 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<CalendarRowS
                 showLoadingEnded();
                 // update the action bar to display the enabled menu options
                 if (Build.VERSION.SDK_INT >= 14) {
-                    invalidateOptionsMenu();
+                    ActivityCompat.invalidateOptionsMenu(CalendarActivity.this);
                 }
                 startService(new Intent(CalendarActivity.this, CalendarManager.QueryLocationsService.class));
             }
@@ -339,7 +339,7 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<CalendarRowS
             public void onClick(DialogInterface arg0, int arg1) {
                 int deleted = CalendarManager.deleteLocalCalendar(CalendarActivity.this);
                 Utils.setInternalSetting(CalendarActivity.this, Const.SYNC_CALENDAR, false);
-                invalidateOptionsMenu();
+                ActivityCompat.invalidateOptionsMenu(CalendarActivity.this);
                 if (deleted > 0) {
                     Utils.showToast(CalendarActivity.this, R.string.calendar_deleted_toast);
                 } else {

--- a/app/src/main/java/de/tum/in/tumcampus/activities/GradesActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampus/activities/GradesActivity.java
@@ -3,6 +3,7 @@ package de.tum.in.tumcampus.activities;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -331,9 +332,9 @@ public class GradesActivity extends ActivityForAccessingTumOnline<ExamList> {
         isFetched = true;
 
         // update the action bar to display the enabled menu options
-        if (Build.VERSION.SDK_INT >= 11) {
-            invalidateOptionsMenu();
-        }
+
+        ActivityCompat.invalidateOptionsMenu(this);
+
 	}
 
 	@Override

--- a/app/src/main/java/de/tum/in/tumcampus/activities/MainActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampus/activities/MainActivity.java
@@ -9,6 +9,7 @@ import android.net.ConnectivityManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.LinearLayoutManager;
@@ -100,7 +101,7 @@ public class MainActivity extends BaseActivity implements SwipeRefreshLayout.OnR
             @Override
             public void onDrawerClosed(View view) {
                 super.onDrawerClosed(view);
-                invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
+                ActivityCompat.invalidateOptionsMenu(MainActivity.this); // creates call to onPrepareOptionsMenu()
             }
 
             /**
@@ -109,7 +110,7 @@ public class MainActivity extends BaseActivity implements SwipeRefreshLayout.OnR
             @Override
             public void onDrawerOpened(View drawerView) {
                 super.onDrawerOpened(drawerView);
-                invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
+                ActivityCompat.invalidateOptionsMenu(MainActivity.this); // creates call to onPrepareOptionsMenu()
             }
         };
 

--- a/app/src/main/java/de/tum/in/tumcampus/adapters/ChatHistoryAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampus/adapters/ChatHistoryAdapter.java
@@ -157,7 +157,6 @@ public class ChatHistoryAdapter extends CursorAdapter {
         }
 
         if (chatMessage.getMember().getLrzId().equals("bot")) {
-            //noinspection deprecation
             holder.tvUser.setText("");
             holder.tvTimestamp.setText("");
         }

--- a/app/src/main/java/de/tum/in/tumcampus/fragments/SettingsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampus/fragments/SettingsFragment.java
@@ -213,7 +213,6 @@ public class SettingsFragment extends PreferenceFragment implements
         }
     }
 
-    @SuppressWarnings("deprecation")
     void setSummary(String key) {
         Preference t = findPreference(key);
         if (t instanceof ListPreference) {

--- a/app/src/main/java/de/tum/in/tumcampus/models/AccessToken.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/AccessToken.java
@@ -3,7 +3,6 @@ package de.tum.in.tumcampus.models;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Text;
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "token")
 public class AccessToken {
     @Text

--- a/app/src/main/java/de/tum/in/tumcampus/models/CalendarRow.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/CalendarRow.java
@@ -3,7 +3,6 @@ package de.tum.in.tumcampus.models;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "event")
 public class CalendarRow {
 	@Element(required = false)

--- a/app/src/main/java/de/tum/in/tumcampus/models/ChatMember.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ChatMember.java
@@ -2,7 +2,6 @@ package de.tum.in.tumcampus.models;
 
 import com.google.gson.annotations.SerializedName;
 
-@SuppressWarnings("UnusedDeclaration")
 public class ChatMember {
 
 	private int id;

--- a/app/src/main/java/de/tum/in/tumcampus/models/ChatMessage.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ChatMessage.java
@@ -10,7 +10,6 @@ import de.tum.in.tumcampus.R;
 import de.tum.in.tumcampus.auxiliary.Utils;
 
 
-@SuppressWarnings("UnusedDeclaration")
 public class ChatMessage {
 
     public static final int STATUS_SENDING = 1;

--- a/app/src/main/java/de/tum/in/tumcampus/models/ChatPublicKey.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ChatPublicKey.java
@@ -1,6 +1,5 @@
 package de.tum.in.tumcampus.models;
 
-@SuppressWarnings("UnusedDeclaration")
 public class ChatPublicKey {
 
 	private String key;

--- a/app/src/main/java/de/tum/in/tumcampus/models/ChatRegistrationId.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ChatRegistrationId.java
@@ -2,7 +2,6 @@ package de.tum.in.tumcampus.models;
 
 import com.google.gson.annotations.SerializedName;
 
-@SuppressWarnings("UnusedDeclaration")
 public class ChatRegistrationId {
 
 	@SerializedName("registration_id")

--- a/app/src/main/java/de/tum/in/tumcampus/models/ChatRoom.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ChatRoom.java
@@ -1,6 +1,5 @@
 package de.tum.in.tumcampus.models;
 
-@SuppressWarnings("UnusedDeclaration")
 public class ChatRoom {
 
 	private String name;

--- a/app/src/main/java/de/tum/in/tumcampus/models/ChatVerification.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ChatVerification.java
@@ -7,7 +7,6 @@ import java.util.Date;
 
 import de.tum.in.tumcampus.auxiliary.RSASigner;
 
-@SuppressWarnings("UnusedDeclaration")
 public class ChatVerification {
 
     private String signature;

--- a/app/src/main/java/de/tum/in/tumcampus/models/ExamList.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/ExamList.java
@@ -11,7 +11,6 @@ import java.util.List;
  * Note: This model is based on the TUMOnline web service response format for a
  * corresponding request.
  */
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "rowset")
 public class ExamList {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/GCMAlert.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/GCMAlert.java
@@ -5,7 +5,6 @@ import java.io.Serializable;
 /**
  * Used for parsing the GCM json payload for the 'alert' type
  */
-@SuppressWarnings("UnusedDeclaration")
 public class GCMAlert implements Serializable {
 
     private static final long serialVersionUID = 3906290674499996501L;

--- a/app/src/main/java/de/tum/in/tumcampus/models/GCMChat.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/GCMChat.java
@@ -6,7 +6,6 @@ import java.io.Serializable;
 /**
  * Used for parsing the GCM json payload for the 'chat' type
  */
-@SuppressWarnings("UnusedDeclaration")
 public class GCMChat implements Serializable {
     private static final long serialVersionUID = -3920974316634829667L;
     public int room;

--- a/app/src/main/java/de/tum/in/tumcampus/models/GCMUpdate.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/GCMUpdate.java
@@ -5,7 +5,6 @@ import java.io.Serializable;
 /**
  * Used for parsing the GCM json payload for the 'update' type
  */
-@SuppressWarnings("UnusedDeclaration")
 public class GCMUpdate implements Serializable {
 
     private static final long serialVersionUID = -4597228673980239217L;

--- a/app/src/main/java/de/tum/in/tumcampus/models/Geo.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/Geo.java
@@ -3,7 +3,6 @@ package de.tum.in.tumcampus.models;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
-@SuppressWarnings({"FieldCanBeLocal","UnusedDeclaration"})
 @Root(name = "geo")
 public class Geo {
     @Element(required = false)

--- a/app/src/main/java/de/tum/in/tumcampus/models/Group.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/Group.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
  * for a corresponding request.
  */
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "gruppe", strict = false)
 public class Group implements Serializable {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/GroupList.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/GroupList.java
@@ -12,7 +12,6 @@ import java.util.List;
  * request.
  */
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "gruppen")
 public class GroupList implements Serializable {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/Identity.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/Identity.java
@@ -3,7 +3,6 @@ package de.tum.in.tumcampus.models;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "row")
 public class Identity {
     @Element

--- a/app/src/main/java/de/tum/in/tumcampus/models/LectureAppointmentsRowSet.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/LectureAppointmentsRowSet.java
@@ -12,7 +12,6 @@ import java.util.List;
  * @see LectureAppointmentsRow
  * @see <a href="http://simple.sourceforge.net/download/stream/doc/tutorial/tutorial.php">SimpleXML tutorial</a>
  */
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "rowset")
 public class LectureAppointmentsRowSet {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/LecturesSearchRow.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/LecturesSearchRow.java
@@ -14,7 +14,6 @@ import de.tum.in.tumcampus.R;
  * @see <a href="http://simple.sourceforge.net/download/stream/doc/tutorial/tutorial.php">SimpleXML tutorial</a>
  */
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "row")
 public class LecturesSearchRow implements Comparable<LecturesSearchRow> {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/OrgDetailsItem.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/OrgDetailsItem.java
@@ -6,7 +6,7 @@ import org.simpleframework.xml.Root;
 /**
  * Model for the organisation details
  */
-@SuppressWarnings({"FieldCanBeLocal","UnusedDeclaration"})
+@SuppressWarnings({"FieldCanBeLocal"})
 @Root(name = "row")
 public class OrgDetailsItem {
     /**

--- a/app/src/main/java/de/tum/in/tumcampus/models/OrgItem.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/OrgItem.java
@@ -11,7 +11,6 @@ import org.simpleframework.xml.Root;
  * @see <a href="http://simple.sourceforge.net/download/stream/doc/tutorial/tutorial.php">SimpleXML tutorial</a>
  */
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "row")
 public class OrgItem {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/PersonList.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/PersonList.java
@@ -10,7 +10,6 @@ import java.util.List;
  * TUMOnline web service response format for a corresponding request.
  */
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "rowset")
 public class PersonList {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/TelSubstationList.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/TelSubstationList.java
@@ -11,7 +11,6 @@ import java.util.List;
  * based on the TUMOnline web service response format for a corresponding
  * request.
  */
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "telefon_nebenstellen")
 public class TelSubstationList implements Serializable {
 

--- a/app/src/main/java/de/tum/in/tumcampus/models/TokenConfirmation.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/TokenConfirmation.java
@@ -3,7 +3,6 @@ package de.tum.in.tumcampus.models;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Text;
 
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "confirmed")
 public class TokenConfirmation {
     @Text

--- a/app/src/main/java/de/tum/in/tumcampus/models/Tuition.java
+++ b/app/src/main/java/de/tum/in/tumcampus/models/Tuition.java
@@ -9,7 +9,6 @@ import org.simpleframework.xml.Root;
  * Note: This model is based on the TUMOnline web service response format for a
  * corresponding request.
  */
-@SuppressWarnings("UnusedDeclaration")
 @Root(name = "row", strict = false)
 public class Tuition {
 

--- a/app/src/main/res/layout-land/layout_error.xml
+++ b/app/src/main/res/layout-land/layout_error.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/error_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -34,6 +35,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/error" />
+        android:src="@drawable/error"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout-land/layout_no_movies.xml
+++ b/app/src/main/res/layout-land/layout_no_movies.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_movies_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -26,6 +27,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/no_movies" />
+        android:src="@drawable/no_movies"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout-land/layout_no_token.xml
+++ b/app/src/main/res/layout-land/layout_no_token.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_token_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -22,6 +23,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/exclamation" />
+        android:src="@drawable/exclamation"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_cafeteria.xml
+++ b/app/src/main/res/layout/activity_cafeteria.xml
@@ -22,7 +22,8 @@
                 android:layout_height="?attr/actionBarSize"
                 android:background="@color/color_primary"
                 android:elevation="12dp"
-                android:theme="@style/ThemeOverlay.AppCompat.Dark">
+                android:theme="@style/ThemeOverlay.AppCompat.Dark"
+                tools:ignore="UnusedAttribute">
 
                 <Spinner
                     android:id="@+id/spinnerToolbar"

--- a/app/src/main/res/layout/activity_cafeteria.xml
+++ b/app/src/main/res/layout/activity_cafeteria.xml
@@ -32,7 +32,7 @@
             </android.support.v7.widget.Toolbar>
         </android.support.design.widget.AppBarLayout>
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal">

--- a/app/src/main/res/layout/activity_kino.xml
+++ b/app/src/main/res/layout/activity_kino.xml
@@ -13,11 +13,11 @@
         <!-- The toolbar aka SupportActionBar -->
         <include layout="@layout/toolbar" />
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal"
-            android:paddingTop="?attr/actionBarSize" >
+            android:paddingTop="?attr/actionBarSize">
 
             <include
                 layout="@layout/layout_all_errors"

--- a/app/src/main/res/layout/activity_openinghours_twopane.xml
+++ b/app/src/main/res/layout/activity_openinghours_twopane.xml
@@ -21,7 +21,8 @@
             android:baselineAligned="false"
             android:orientation="horizontal"
             android:showDividers="middle"
-            tools:context="OpeningHoursListActivity">
+            tools:context="OpeningHoursListActivity"
+            tools:ignore="UnusedAttribute">
 
             <fragment
                 android:id="@+id/item_list"

--- a/app/src/main/res/layout/activity_setup_eduroam.xml
+++ b/app/src/main/res/layout/activity_setup_eduroam.xml
@@ -38,7 +38,6 @@
                 android:layout_marginLeft="4dp"
                 android:layout_marginRight="4dp"
                 android:layout_marginTop="4dp"
-                android:fontFamily="sans-serif"
                 android:hint="@string/password"
                 android:inputType="textPassword" />
 

--- a/app/src/main/res/layout/card_eduroam.xml
+++ b/app/src/main/res/layout/card_eduroam.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:id="@+id/card_view"

--- a/app/src/main/res/layout/card_first_use1.xml
+++ b/app/src/main/res/layout/card_first_use1.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/card_first_use2.xml
+++ b/app/src/main/res/layout/card_first_use2.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/card_item.xml
+++ b/app/src/main/res/layout/card_item.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:id="@+id/card_view"

--- a/app/src/main/res/layout/card_news_film_item.xml
+++ b/app/src/main/res/layout/card_news_film_item.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
         <LinearLayout
             android:id="@+id/card_view"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/card_news_item.xml
+++ b/app/src/main/res/layout/card_news_item.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:id="@+id/card_view"

--- a/app/src/main/res/layout/card_next_lecture_item.xml
+++ b/app/src/main/res/layout/card_next_lecture_item.xml
@@ -14,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:id="@+id/card_view"

--- a/app/src/main/res/layout/card_no_internet.xml
+++ b/app/src/main/res/layout/card_no_internet.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:id="@+id/card_view"

--- a/app/src/main/res/layout/card_restore.xml
+++ b/app/src/main/res/layout/card_restore.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -14,7 +15,8 @@
         android:elevation="@dimen/cardview_elevation"
         android:onClick="restoreCards"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <RelativeLayout
             android:id="@+id/card_view"

--- a/app/src/main/res/layout/card_support.xml
+++ b/app/src/main/res/layout/card_support.xml
@@ -1,5 +1,6 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,7 +14,8 @@
         android:layout_marginTop="@dimen/card_padding_vertical"
         android:elevation="@dimen/cardview_elevation"
         card_view:cardBackgroundColor="#fff"
-        card_view:cardCornerRadius="3dp">
+        card_view:cardCornerRadius="3dp"
+        tools:ignore="UnusedAttribute">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="172dp"
     android:background="@drawable/wear_tuition_fee"
@@ -13,7 +14,8 @@
         android:layout_height="64dp"
         android:layout_margin="20dp"
         android:elevation="4dp"
-        android:src="@drawable/photo_not_available" />
+        android:src="@drawable/photo_not_available"
+        tools:ignore="UnusedAttribute" />
 
     <TextView
         android:id="@+id/name"

--- a/app/src/main/res/layout/header.xml
+++ b/app/src/main/res/layout/header.xml
@@ -8,4 +8,5 @@
     android:paddingRight="16dp"
     android:paddingTop="5dp"
     android:textColor="#fff"
-    android:textSize="16sp" />
+    android:textSize="16sp"
+    android:textIsSelectable="false" />

--- a/app/src/main/res/layout/layout_error.xml
+++ b/app/src/main/res/layout/layout_error.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/error_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -37,6 +38,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/error" />
+        android:src="@drawable/error"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/layout_failed_token.xml
+++ b/app/src/main/res/layout/layout_failed_token.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/failed_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -23,6 +24,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/exclamation" />
+        android:src="@drawable/exclamation"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/layout_no_internet.xml
+++ b/app/src/main/res/layout/layout_no_internet.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_internet_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -24,7 +25,8 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/ic_no_wifi" />
+        android:src="@drawable/ic_no_wifi"
+        tools:ignore="UnusedAttribute" />
 
     <Button
         android:id="@+id/button_enable_wifi"

--- a/app/src/main/res/layout/layout_no_movies.xml
+++ b/app/src/main/res/layout/layout_no_movies.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_movies_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -26,6 +27,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/no_movies" />
+        android:src="@drawable/no_movies"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/layout_no_token.xml
+++ b/app/src/main/res/layout/layout_no_token.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/no_token_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -23,6 +24,7 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:alpha="0.5"
-        android:src="@drawable/exclamation" />
+        android:src="@drawable/exclamation"
+        tools:ignore="UnusedAttribute" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -11,5 +12,6 @@
         android:background="@color/color_primary"
         android:elevation="12dp"
         android:theme="@style/ThemeOverlay.AppCompat.Dark"
-        app:layout_scrollFlags="scroll|enterAlways" />
+        app:layout_scrollFlags="scroll|enterAlways"
+        tools:ignore="UnusedAttribute" />
 </android.support.design.widget.AppBarLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,7 +108,7 @@
     <string name="info_title">Neuigkeiten:</string>
 
     <!-- Kino -->
-    <string name="imdb_rating">IMDB-Rating</string>
+    <string name="imdb_rating">IMDb-Wertung</string>
     <string name="year">Erscheinungsjahr</string>
     <string name="runtime">Laufzeit</string>
     <string name="genre">Genre</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -348,5 +348,18 @@
     <string name="pin_lock_desc">Para configurar la conexión inalámbrica se requiere un bloqueo de PIN.\nSi usted no tiene ya utilizar el bloqueo de PIN usted puede configurarlo aquí.\n<a href="https://www.tum.de/index.php?id=1821&amp;tx_ttnews%5Btt_news%5D=31688">Más información</a></string>
     <string name="support_us_title">¡Apoyanos!</string>
     <string name="ok">OK</string>
+    <string name="actors">Actores</string>
+    <string name="always">Siempre</string>
+    <string name="description">Descripción</string>
+    <string name="director">Directora</string>
+    <string name="genre">Género</string>
+    <string name="imdb_rating">Puntuación IMDb</string>
+    <string name="mode_background_mode">La activación del modo de fondo</string>
+    <string name="no_movies">Actualmente no hay películas.</string>
+    <string name="permission_calendar_explanation">Esta aplicación necesita permiso para acceder a su ubicación para mostrar información útil, por ejemplo, los menús de las cafeterías alrededor de usted o los horarios de su estación de MVV más cercano. \n Si no otorga este permiso usted todavía será capaz de configurar su ubicación en la configuración.</string>
+    <string name="permission_location_explanation">Esta aplicación necesita permiso para acceder a su calendario para poder sincronizarlo con el calendario de la TUM.</string>
+    <string name="runtime">Duración</string>
+    <string name="wifi_only">Sólo WiFi</string>
+    <string name="year">Año de publicación </string>
     <!-- END Translated, please do not change identifiers -->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -356,4 +356,17 @@
     <string name="public_key_mail">Mail d\'activation envoyé à clé publique %s@mytum.de.\n\n<b>S\'il vous plaît activer maintenant!</b></string>
     <string name="support_us_title">Soutenez-nous!</string>
     <string name="ok">OK</string>
+    <string name="actors">Acteurs</string>
+    <string name="always">Toujours</string>
+    <string name="description">Description</string>
+    <string name="director">Directeur</string>
+    <string name="genre">Genre</string>
+    <string name="imdb_rating">IMDb note</string>
+    <string name="mode_background_mode">Fond activation de mode</string>
+    <string name="no_movies">Actuellement, il n\'y a pas de films.</string>
+    <string name="permission_calendar_explanation">Cette application a besoin de la permission pour accéder à votre emplacement pour afficher des informations utiles, par exemple, les menus des cantines autour de vous ou les horaires de votre station de MVV plus proche. \n Si vous ne accordez pas cette autorisation, vous serez toujours en mesure de configurer votre emplacement dans les paramètres.</string>
+    <string name="permission_location_explanation">Cette application a besoin de la permission pour accéder à votre calendrier pour être en mesure de le synchroniser avec votre calendrier de TUM.</string>
+    <string name="runtime">Durée</string>
+    <string name="wifi_only">WiFi seulement</string>
+    <string name="year">Année de publication</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,8 +336,8 @@
     <string name="closed">Closed</string>
 
     <!-- Kino -->
-    <string name="kino">TU Kino</string>
-    <string name="imdb_rating">IMDB-Rating</string>
+    <string name="kino" translatable="false">TU Kino</string>
+    <string name="imdb_rating">IMDb-Rating</string>
     <string name="year">Year of release</string>
     <string name="runtime">Runtime</string>
     <string name="genre">Genre</string>


### PR DESCRIPTION
Currently, we don't treat AndroidLint as real warnings or errors.
This PR enables treating AndroidLint as compilation errors and travis will tell you why.

I've disabeled a whole bunch of warnings, since they were too many (~300) to fix at once.