### PR TITLE
MMV-Plans feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,15 @@
             android:name="de.tum.in.tumcampusapp.auxiliary.LectureSearchSuggestionProvider"
             android:authorities="de.tum.in.tumcampusapp.auxiliary.LectureSearchSuggestionProvider"
             android:exported="false" />
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="de.tum.in.tumcampusapp.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/fileprovider" />
+        </provider>
 
         <activity
             android:name="de.tum.in.tumcampusapp.activities.StartupActivity"

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/FileDownloader.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/FileDownloader.java
@@ -1,0 +1,40 @@
+package de.tum.in.tumcampusapp.activities;
+
+import android.content.Context;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class FileDownloader {
+    private static final int  MEGABYTE = 1024 * 1024;
+
+    public static void downloadFile(String fileName, String fileUrl, Context ctx){
+        try {
+            URL url = new URL(fileUrl);
+            HttpURLConnection urlConnection = (HttpURLConnection)url.openConnection();
+            urlConnection.connect();
+
+            InputStream inputStream = urlConnection.getInputStream();
+            FileOutputStream fileOutputStream = ctx.openFileOutput(fileName,Context.MODE_PRIVATE);//new FileOutputStream(directory);
+            int totalSize = urlConnection.getContentLength();
+
+            byte[] buffer = new byte[MEGABYTE];
+            int bufferLength = 0;
+            while((bufferLength = inputStream.read(buffer))>0 ){
+                fileOutputStream.write(buffer, 0, bufferLength);
+            }
+            fileOutputStream.close();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/PlansActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/PlansActivity.java
@@ -61,7 +61,7 @@ public class PlansActivity extends BaseActivity implements OnItemClickListener {
 
             new AlertDialog.Builder(this)
                     .setTitle("MVV plans")
-                    .setMessage("Please press ok to download mvv plans otherwise you can't use this feature")
+                    .setMessage(getResources().getString(R.string.mvv_download))
                     .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int which) {
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/PlansActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/PlansActivity.java
@@ -47,12 +47,12 @@ public class PlansActivity extends BaseActivity implements OnItemClickListener {
 
         if (!sharedPref.contains("mvvplans_downloaded")) {
             editor.putInt("mvvplans_downloaded",0);
-            editor.commit();
+            editor.apply();
         }
 
         if (!sharedPref.contains("mvvplans_downloaded")) {
             editor.putInt("mvvplans_downloaded",0);
-            editor.commit();
+            editor.apply();
         }
 
         if(sharedPref.getInt("mvvplans_downloaded",0) == 0){
@@ -85,7 +85,7 @@ public class PlansActivity extends BaseActivity implements OnItemClickListener {
                             SharedPreferences sharedPref = getPreferences(Context.MODE_PRIVATE);
                             SharedPreferences.Editor editor = sharedPref.edit();
                             editor.putInt("mvvplans_downloaded",1);
-                            editor.commit();
+                            editor.apply();
                         }
                     })
                     .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/PlansActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/PlansActivity.java
@@ -1,12 +1,22 @@
 package de.tum.in.tumcampusapp.activities;
 
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.CountDownTimer;
+import android.support.v4.content.FileProvider;
+import android.support.v7.app.AlertDialog;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ListView;
+import android.widget.ProgressBar;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import de.tum.in.tumcampusapp.R;
@@ -29,7 +39,66 @@ public class PlansActivity extends BaseActivity implements OnItemClickListener {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		ListView list = (ListView) findViewById(R.id.activity_plans_list_view);
+        final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progressBar2);
+        progressBar.setVisibility(View.GONE);
+
+		SharedPreferences sharedPref = getPreferences(Context.MODE_PRIVATE);
+		SharedPreferences.Editor editor = sharedPref.edit();
+
+        if (!sharedPref.contains("mvvplans_downloaded")) {
+            editor.putInt("mvvplans_downloaded",0);
+            editor.commit();
+        }
+
+        if (!sharedPref.contains("mvvplans_downloaded")) {
+            editor.putInt("mvvplans_downloaded",0);
+            editor.commit();
+        }
+
+        if(sharedPref.getInt("mvvplans_downloaded",0) == 0){
+
+            final Intent back_intent = new Intent(this, MainActivity.class);
+
+            new AlertDialog.Builder(this)
+                    .setTitle("MVV plans")
+                    .setMessage("Please press ok to download mvv plans otherwise you can't use this feature")
+                    .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+
+                            new CountDownTimer(3000, 100) {
+                                @Override
+                                public void onTick(long millisUntilFinished) {
+                                    progressBar.setVisibility(View.VISIBLE);
+                                }
+                                @Override
+                                public void onFinish() {
+                                    progressBar.setVisibility(View.GONE);
+                                }
+
+                            }.start();
+
+                            new DownloadFile().execute("http://www.mvv-muenchen.de/fileadmin/media/Dateien/plaene/pdf/Netz_2016_Version_MVG.PDF", "Schnellbahnnetz.pdf");
+                            new DownloadFile().execute("http://www.mvv-muenchen.de/fileadmin/media/Dateien/plaene/pdf/Nachtnetz_2016.pdf", "Nachtliniennetz.pdf");
+                            new DownloadFile().execute("http://www.mvv-muenchen.de/fileadmin/media/Dateien/plaene/pdf/Tramnetz_2016.pdf", "Tramnetz.pdf");
+                            new DownloadFile().execute("http://www.mvv-muenchen.de/fileadmin/media/Dateien/3_Tickets_Preise/dokumente/TARIFPLAN_2016-Innenraum.pdf","Tarifplan.pdf");
+
+                            SharedPreferences sharedPref = getPreferences(Context.MODE_PRIVATE);
+                            SharedPreferences.Editor editor = sharedPref.edit();
+                            editor.putInt("mvvplans_downloaded",1);
+                            editor.commit();
+                        }
+                    })
+                    .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            startActivity(back_intent);
+                        }
+                    })
+                    .setIcon(android.R.drawable.ic_dialog_alert)
+                    .show();
+        }
+
+
+        ListView list = (ListView) findViewById(R.id.activity_plans_list_view);
 		ArrayList<PlanListEntry> listMenuEntrySet = new ArrayList<>();
         listMenuEntrySet.add(new PlanListEntry(R.drawable.plan_mvv_icon,
                 R.string.mvv_fast_train_net, R.string.empty_string, R.drawable.mvv));
@@ -68,10 +137,44 @@ public class PlansActivity extends BaseActivity implements OnItemClickListener {
 
 	@Override
 	public void onItemClick(AdapterView<?> adapterView, View view, int pos, long id) {
-		Intent intent = new Intent(this, PlansDetailsActivity.class);
+        Intent intent = new Intent(this, PlansDetailsActivity.class);
         PlanListEntry entry = (PlanListEntry) mListAdapter.getItem(pos);
-        intent.putExtra(PlansDetailsActivity.PLAN_TITLE_ID, entry.titleId);
-		intent.putExtra(PlansDetailsActivity.PLAN_IMG_ID, entry.imgId);
-		startActivity(intent);
+
+        File pdfFile;
+        if(pos <= 3){
+            switch (pos){
+                case 0: pdfFile = new File(getFilesDir(), "Schnellbahnnetz.pdf");
+                    break;
+                case 1: pdfFile = new File(getFilesDir(), "Nachtliniennetz.pdf");
+                    break;
+                case 2: pdfFile = new File(getFilesDir(), "Tramnetz.pdf");
+                    break;
+                default: pdfFile = new File(getFilesDir(), "Tarifplan.pdf");
+                    break;
+            }
+
+            final Uri path = FileProvider.getUriForFile(getApplicationContext(), "de.tum.in.tumcampusapp.fileprovider", pdfFile);
+
+            Intent x = new Intent();
+            x.setData(path);
+            x.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            setResult(RESULT_OK,x);
+            startActivity(x);
+        } else {
+            intent.putExtra(PlansDetailsActivity.PLAN_TITLE_ID, entry.titleId);
+            intent.putExtra(PlansDetailsActivity.PLAN_IMG_ID, entry.imgId);
+            startActivity(intent);
+        }
 	}
+
+    private class DownloadFile extends AsyncTask<String, Void, Void> {
+
+        @Override
+        protected Void doInBackground(String... strings) {
+            String fileUrl = strings[0];
+            String fileName = strings[1];
+            FileDownloader.downloadFile(fileName, fileUrl, getApplicationContext());
+            return null;
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_plans.xml
+++ b/app/src/main/res/layout/activity_plans.xml
@@ -22,6 +22,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
+            <ProgressBar
+                android:id="@+id/progressBar2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:max="500"
+                android:progress="0"
+                android:layout_centerVertical="true"
+                android:layout_centerHorizontal="true" />
         </RelativeLayout>
 
     </LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -383,4 +383,5 @@ Signatur: %5$s</string>
     <string name="free">Frei</string>
     <string name="occupied">Belegt bis</string>
     <string name="study_rooms">Lernräume</string>
+    <string name="mvv_download">Bitte auf ok klicken um die MVV-Plans herunterzuladen, sonst kannst Du dieses Feature nicht benutzen</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -383,5 +383,4 @@ Signatur: %5$s</string>
     <string name="free">Frei</string>
     <string name="occupied">Belegt bis</string>
     <string name="study_rooms">Lernräume</string>
-    <string name="mvv_download">Bitte auf ok klicken um die MVV-Plans herunterzuladen, sonst kannst Du dieses Feature nicht benutzen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,4 +448,5 @@ Signature: %5$s</string>
     <string name="alarm_date_published_on">Published on:</string>
     <string name="chat_not_setup" translatable="false">Chat is not setup properly, please re-run the wizzard via the settings!</string>
     <string name="www" translatable="false">www</string>
+    <string name="mvv_download" translatable="false">Please press ok to download MVV-Plans otherwise you can\'t use this feature</string>
 </resources>

--- a/app/src/main/res/xml/fileprovider.xml
+++ b/app/src/main/res/xml/fileprovider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="files"/>
+</paths>


### PR DESCRIPTION
- Created file provider to share downloaded pdfs with external apps
- Defined the file provider in the manifest
- Created FileDownloader help class to download the mvv plans from the website
- modified plansActivity respectively.

Please consider the following:
1. There is a new version of the document "Nachliniennetz" compared to the one currently used in the app
2. In the "Overallplan" we did not crop the rings only, since we are taking the whole pdf
3. Only the first 4 documents will be downloaded from the mvv website, the rest is not from mvv (we assume)

Downloaded pdfs:
1. Schnellbahnnetz mit Tram und Expressbus: http://www.mvv-muenchen.de/fileadmin/media/Dateien/plaene/pdf/Netz_2016_Version_MVG.PDF
2. Nachtliniennetz: http://www.mvv-muenchen.de/fileadmin/media/Dateien/plaene/pdf/Nachtnetz_2016.pdf
3. Tramnetz: http://www.mvv-muenchen.de/fileadmin/media/Dateien/plaene/pdf/Tramnetz_2016.pdf
4. MVV Overall-Network: http://www.mvv-muenchen.de/fileadmin/media/Dateien/3_Tickets_Preise/dokumente/TARIFPLAN_2016-Innenraum.pdf