### PR TITLE
Stilistic improvements in the German resource file

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -37,16 +37,6 @@
     <string name="dialog_access_token_invalid">TUMonline-Access-Token nicht aktiviert</string>
     <string name="dialog_no_rights_function">Keine Rechte für diese Funktion</string>
     <string name="empty_result">Die Anfrage lieferte ein fehlerhaftes Ergebnis</string>
-
-    <!-- Exam/Grades -->
-    <string name="average_grade">Durchschnittsnote</string>
-    <string name="show_column_chart">Zeige als Balkendiagramm</string>
-    <string name="show_pie_chart">Zeige als Tortendiagramm</string>
-    <string name="result_extra">Ergebnis:&#160;</string>
-    <string name="semester">Semester</string>
-    <string name="examiner">Prüfer</string>
-    <string name="mode">Modus</string>
-    <string name="all_programs">Alle Programme</string>
     <string name="date">Datum</string>
 
     <!-- Preferences -->
@@ -72,9 +62,9 @@
     <string name="services">Dienste</string>
     <string name="silence_phone">Lautlos Service</string>
     <string name="silence_phone_info">Das Gerät wird während einer Vorlesung automatisch in den lautlosen Modus gestellt.</string>
-    <string name="background_mode">Hintergrund Modus (Empfohlen)</string>
+    <string name="background_mode">Hintergrundmodus (empfohlen)</string>
     <string name="background_info">Aktualisiert die Inhalte der App einmal täglich, um dich auf dem neusten Stand zu halten, sogar wenn die App nicht geöffnet ist.</string>
-    <string name="mode_background_mode">Aktivierung des Hintergrund Modus</string>
+    <string name="mode_background_mode">Aktivierung des Hintergrundmodus</string>
     <string name="always">Immer</string>
     <string name="wifi_only">Nur bei WLAN-Verbindung</string>
     <string name="demo_mode">In-App-Tutorial</string>
@@ -99,7 +89,7 @@
     <string name="step_4">Schritt 4</string>
     <string name="step_5">Schritt 5</string>
     <string name="set_silent_mode">Aktiviere oder deaktiviere den <i>Lautlos Service</i>. Bei Aktivierung wird sich das Gerät bei einer aktuell stattfindenden Vorlesung lautlos schalten.</string>
-    <string name="set_background_mode">Aktiviere oder deaktiviere den <i>Hintergrund Modus</i>. Bei Aktivierung werden einmal am Tag im Hintergrund alle Inhalte heruntergeladen, um deine TUM Campus App auf den neusten Stand zu halten.</string>
+    <string name="set_background_mode">Aktiviere oder deaktiviere den <i>Hintergrundmodus</i>. Bei Aktivierung werden einmal am Tag im Hintergrund alle Inhalte heruntergeladen, um deine TUM Campus App auf den neusten Stand zu halten.</string>
     <string name="goto_tumcampus">Starte TUM Campus App</string>
 
     <!-- News -->
@@ -122,7 +112,6 @@
     <string name="my_tum">Mein TUM</string>
     <string name="schedule">Kalender</string>
     <string name="my_lectures">Meine Vorlesungen</string>
-    <string name="my_grades">Meine Noten</string>
     <string name="chat_rooms">Chatrooms</string>
     <string name="tuition_fees">Rückmeldung</string>
     <string name="tum_common">TUM Allgemein</string>
@@ -264,8 +253,8 @@
     <!-- END Translated, please do not change identifiers -->
 
     <string name="min_search_len">Text muss mindestens %d Zeichen lang sein</string>
-    <string name="default_cafeteria">Standard Mensa</string>
-    <string name="default_station">Standard Haltestelle</string>
+    <string name="default_cafeteria">Standardmensa</string>
+    <string name="default_station">Standardhaltestelle</string>
     <string name="campus_klinikum_großhadern">Klinikum Großhadern</string>
     <string name="cafeteria">Mensa</string>
     <string name="card_cafeteria_summary">Zeigt den Mensa-Speiseplan an</string>
@@ -350,8 +339,8 @@ Signatur: %5$s</string>
     <string name="status_sending_failed">Senden fehlgeschlagen</string>
     <string name="joined">Meine</string>
     <string name="not_joined">Weitere</string>
-    <string name="default_campus">Standard Campus</string>
-    <string name="no_default_campus">Kein Standard Campus</string>
+    <string name="default_campus">Standardcampus</string>
+    <string name="no_default_campus">Kein Standardcampus</string>
     <string name="public_key_mail">Public Key Aktivierungs-E-Mail wurde an %s@mytum.de gesendet!\n\n<b>Bitte aktiviere ihn jetzt!</b></string>
     <string name="failure_uploading_public_key">Fehler beim Hochladen des Public Key</string>
     <string name="key_not_activated">Du hast deinen Key noch nicht aktiviert!</string>


### PR DESCRIPTION
My Pull request contains some improvements of the German strings of the app

https://de.wikipedia.org/wiki/Plenk
Ist natürlich Geschmackssache, aber ich finde diese falschen Leerzeichen schwer zu lesen. Im Deutschen (nicht im Englischen) schreibt man solche Kompostita im Allgemeinen zusammen.

EDIT:
Why did I delete lines 40-49? It was not intended by me. I'm not familiar with github, sorry