### PR TITLE
Less lax rounding times

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/DateUtils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/DateUtils.java
@@ -2,8 +2,6 @@ package de.tum.in.tumcampusapp.auxiliary;
 
 import android.content.Context;
 
-import net.danlew.android.joda.JodaTimeAndroid;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -40,7 +38,7 @@ public final class DateUtils {
 
         final long diff =  timeInMillis - now;
         if (diff < 60 * MINUTE_MILLIS) {
-            SimpleDateFormat formatter = new SimpleDateFormat("mm", Locale.ENGLISH);
+            SimpleDateFormat formatter = new SimpleDateFormat("m", Locale.ENGLISH);
             return "in " + formatter.format(new Date(diff)) + " minuten";
         } else if (diff < 3 * HOUR_MILLIS) { // Be more precise by telling the user the exact time if below 3 hours
             SimpleDateFormat formatter = new SimpleDateFormat("HH:mm", Locale.ENGLISH);

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/DateUtils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/DateUtils.java
@@ -36,13 +36,13 @@ public final class DateUtils {
             return DateUtils.getTimeOrDay(time, context);
         }
 
-        final long diff =  timeInMillis - now;
+        final long diff = timeInMillis - now;
         if (diff < 60 * MINUTE_MILLIS) {
             SimpleDateFormat formatter = new SimpleDateFormat("m", Locale.ENGLISH);
-            return "in " + formatter.format(new Date(diff)) + " minuten";
+            return context.getString(R.string.IN) + formatter.format(new Date(diff)) + " " + context.getString(R.string.MINUTES);
         } else if (diff < 3 * HOUR_MILLIS) { // Be more precise by telling the user the exact time if below 3 hours
             SimpleDateFormat formatter = new SimpleDateFormat("HH:mm", Locale.ENGLISH);
-            return "um " + formatter.format(time);
+            return context.getString(R.string.AT) + " " + formatter.format(time);
         } else {
             return android.text.format.DateUtils.getRelativeTimeSpanString(timeInMillis, now, android.text.format.DateUtils.MINUTE_IN_MILLIS, android.text.format.DateUtils.FORMAT_ABBREV_RELATIVE).toString();
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/NextLectureCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/NextLectureCard.java
@@ -11,7 +11,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 import android.support.v7.widget.RecyclerView;
-import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -30,6 +29,7 @@ import java.util.Locale;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.activities.CalendarActivity;
 import de.tum.in.tumcampusapp.activities.RoomFinderActivity;
+import de.tum.in.tumcampusapp.auxiliary.DateUtils;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.cards.generic.Card;
 import de.tum.in.tumcampusapp.cards.generic.NotificationAwareCard;
@@ -109,8 +109,7 @@ public class NextLectureCard extends NotificationAwareCard {
         mTitleView.setText(getTitle());
 
         //Add content
-        mTimeView.setText(DateUtils.getRelativeTimeSpanString(item.start.getTime(),
-                System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE));
+        mTimeView.setText(DateUtils.getFutureTime(item.start, mContext));
 
         //Add location with link to room finder
         if (item.location == null || item.location.isEmpty()) {
@@ -167,8 +166,7 @@ public class NextLectureCard extends NotificationAwareCard {
     @Override
     protected Notification fillNotification(NotificationCompat.Builder notificationBuilder) {
         CalendarItem item = lectures.get(0);
-        final String time = DateUtils.getRelativeDateTimeString(mContext, item.start.getTime(),
-                DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0).toString();
+        final String time = DateUtils.getFutureTime(item.start, mContext);
         notificationBuilder.setContentText(item.title + '\n' + time);
         Bitmap bm = BitmapFactory.decodeResource(mContext.getResources(), R.drawable.wear_next_lecture);
         notificationBuilder.extend(new NotificationCompat.WearableExtender().setBackground(bm));

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/OpenHoursManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/OpenHoursManager.java
@@ -2,7 +2,6 @@ package de.tum.in.tumcampusapp.managers;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.text.format.DateUtils;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -12,6 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import de.tum.in.tumcampusapp.R;
+import de.tum.in.tumcampusapp.auxiliary.DateUtils;
 import de.tum.in.tumcampusapp.models.cafeteria.Location;
 
 /**
@@ -152,7 +152,7 @@ public class OpenHoursManager extends AbstractManager {
         }
 
         //Get the relative string
-        String relStr = DateUtils.getRelativeTimeSpanString(relativeTo.getTimeInMillis(), now.getTimeInMillis(), DateUtils.MINUTE_IN_MILLIS).toString();
+        String relStr = DateUtils.getFutureTime(relativeTo.getTime(), context);
 
         //Return an assembly
         return context.getString(relation) + " " + relStr.substring(0, 1).toLowerCase(Locale.getDefault()) + relStr.substring(1);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -414,4 +414,7 @@ Signatur: %5$s</string>
     <string name="flag_inappropriate">Unangemessene Frage melden</string>
     <string name="mvv_download">Bitte klicken Sie auf OK, um MVV-Pläne herunterzuladen, sonst können Sie diese Funktion nicht verwenden</string>
     <string name="please_connect_to_internet">Bitte verbinden Sie sich mit dem Internet, um den ersten App-Start fortzusetzen</string>
+    <string name="IN">in</string>
+    <string name="MINUTES">minuten</string>
+    <string name="AT">um</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -395,5 +395,8 @@
     <string name="flag_inappropriate">Bandera inapropiada pregunta</string>
     <string name="mvv_download">Por favor, pulse OK para descargar MVV-Planes de otro modo no se puede utilizar esta función</string>
     <string name="please_connect_to_internet">Por favor, conectarse a Internet con el fin de proceder al primer inicio de aplicaciones</string>
+    <string name="MINUTES">minutos</string>
+    <string name="IN">en</string>
+    <string name="AT">a</string>
     <!-- END Translated, please do not change identifiers -->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -403,5 +403,8 @@
     <string name="please_connect_to_internet">S\'il vous plaît vous connecter à Internet afin de procéder au premier démarrage de l\'application</string>
     <string name="mvv_download">S\'il vous plaît appuyez sur OK pour télécharger MVV-plans, sinon vous ne pouvez pas utiliser cette fonctionnalité</string>
     <string name="flag_inappropriate">Flag question inappropriée</string>
+    <string name="IN">dans</string>
+    <string name="MINUTES">minutes</string>
+    <string name="AT">à</string>
 
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -329,4 +329,7 @@
     <string name="flag_inappropriate">Flag domanda inadeguato</string>
     <string name="mvv_download">Si prega di premere OK per scaricare MVV-Piani altrimenti non è possibile utilizzare questa funzione</string>
     <string name="please_connect_to_internet">Si prega di collegarsi a Internet al fine di procedere al primo avvio dell\'applicazione</string>
+    <string name="IN">in</string>
+    <string name="MINUTES">minuti</string>
+    <string name="AT">a</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -329,4 +329,7 @@
     <string name="please_connect_to_internet">Пожалуйста, подключиться к Интернету, чтобы продолжить первый запуск приложения</string>
     <string name="mvv_download">Пожалуйста, нажмите кнопку OK, чтобы загрузить MVV-планы в противном случае вы не можете использовать эту функцию</string>
     <string name="flag_inappropriate">Флаг неуместный вопрос</string>
+    <string name="IN">в</string>
+    <string name="MINUTES">минут</string>
+    <string name="AT">в</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,6 +486,9 @@ Signature: %5$s</string>
     <string name="transition_card" translatable="false">card_transition</string>
     <string name="tumonline_link" translatable="false"><a href="http://campus.tum.de">TUMonline</a></string>
     <string name="accept_chat_terms">Terms must be accepted to use group chat!</string>
+    <string name="IN">in</string>
+    <string name="MINUTES">minutes</string>
+    <string name="AT">at</string>
 </resources>
 
 


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #346 

## Screenshot

More than 3 hours in the future:
![screenshot_1480112484](https://cloud.githubusercontent.com/assets/298860/20636044/3101c0b0-b366-11e6-95f0-f8e70b1fc499.png)

Less than 3 hours:
![screenshot_1480112474](https://cloud.githubusercontent.com/assets/298860/20636042/30d806f8-b366-11e6-901f-0de49846302b.png)

Less than 1 hour:
![screenshot_1480112462](https://cloud.githubusercontent.com/assets/298860/20636043/30f0e6d2-b366-11e6-91de-b2930216bbcb.png)

## Why this is useful for all students:

less confusion, when the lecture starts. Sometimes an exact time is just more practical. 

@woodpecker2010 what do you think?


