### PR TITLE
update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,22 +47,22 @@ android {
 
 configurations.all {
     resolutionStrategy {
-        force 'com.android.support:design:25.1.0'
-        force 'com.android.support:recyclerview-v7:25.1.0'
+        force 'com.android.support:design:25.2.0'
+        force 'com.android.support:recyclerview-v7:25.2.0'
         force 'com.google.code.findbugs:jsr305:3.0.1'
     }
 }
 
 dependencies {
-    compile 'com.android.support:cardview-v7:25.1.0'
-    compile 'com.android.support:design:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
-    compile 'com.google.android.gms:play-services-gcm:10.0.1'
+    compile 'com.android.support:cardview-v7:25.2.0'
+    compile 'com.android.support:design:25.2.0'
+    compile 'com.android.support:preference-v7:25.2.0'
+    compile 'com.google.android.gms:play-services-gcm:10.2.0'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.google.guava:guava:20.0'
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+    compile 'com.squareup.retrofit2:retrofit:2.2.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.2.0'
     compile 'com.github.chrisbanes:PhotoView:1.3.0'
     compile 'me.dm7.barcodescanner:zxing:1.9'
     compile('org.simpleframework:simple-xml:2.7.1') {
@@ -75,7 +75,7 @@ dependencies {
     compile 'net.danlew:android.joda:2.9.5'
     compile 'com.github.franmontiel:PersistentCookieJar:v1.0.0'
 
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:25.2.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/TumHttpLoggingInterceptor.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/TumHttpLoggingInterceptor.java
@@ -15,12 +15,12 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okhttp3.internal.Platform;
-import okhttp3.internal.http.HttpEngine;
+import okhttp3.internal.http.HttpHeaders;
+import okhttp3.internal.platform.Platform;
 import okio.Buffer;
 import okio.BufferedSource;
 
-import static okhttp3.internal.Platform.INFO;
+import static okhttp3.internal.platform.Platform.INFO;
 
 public final class TumHttpLoggingInterceptor implements Interceptor {
 
@@ -137,7 +137,7 @@ public final class TumHttpLoggingInterceptor implements Interceptor {
                 logger.log(headers.name(i) + ": " + headers.value(i));
             }
 
-            if (logBody && HttpEngine.hasBody(response)) {
+            if (logBody && HttpHeaders.hasBody(response)) {
                 if (bodyEncoded(response.headers())) {
                     logger.log("<-- END HTTP (encoded body omitted)");
                 } else {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip


### PR DESCRIPTION
@kordianbruck 😲 can't directly push to the master branch anymore

Guava 21 doesn't work with Android, yet
>If you need support for (…) Android, use 20.0 for now. In the next release (22.0) we will begin providing a backport for use on Android