### PR TITLE
Migrate the cache manager to also reside in cache

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/fragments/SettingsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/fragments/SettingsFragment.java
@@ -35,7 +35,6 @@ import de.tum.in.tumcampusapp.auxiliary.Const;
 import de.tum.in.tumcampusapp.auxiliary.NetUtils;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.managers.AbstractManager;
-import de.tum.in.tumcampusapp.managers.CacheManager;
 import de.tum.in.tumcampusapp.managers.CalendarManager;
 import de.tum.in.tumcampusapp.managers.CardManager;
 import de.tum.in.tumcampusapp.managers.NewsManager;
@@ -295,9 +294,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
      */
     private void clearCache() {
         AbstractManager.resetDb(mContext);
-
-        CacheManager manager = new CacheManager(mContext);
-        manager.clearCache();
 
         // delete local calendar
         Utils.setInternalSetting(mContext, Const.SYNC_CALENDAR, false);

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/AbstractManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/AbstractManager.java
@@ -1,11 +1,16 @@
 package de.tum.in.tumcampusapp.managers;
 
 import android.content.Context;
+import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 
 import java.io.File;
 
 import de.tum.in.tumcampusapp.auxiliary.Const;
+import de.tum.in.tumcampusapp.services.BackgroundService;
+import de.tum.in.tumcampusapp.services.DownloadService;
+import de.tum.in.tumcampusapp.services.SendMessageService;
+import de.tum.in.tumcampusapp.services.SilenceService;
 
 public class AbstractManager {
     protected Context mContext;
@@ -29,36 +34,60 @@ public class AbstractManager {
             if (globalDb == null) {
                 File f = c.getDatabasePath(Const.DATABASE_NAME);
                 f.getParentFile().mkdirs();
-                globalDb = SQLiteDatabase.openDatabase(f.toString(),
-                        null, SQLiteDatabase.CREATE_IF_NECESSARY);
+                globalDb = SQLiteDatabase.openOrCreateDatabase(f, null);
             }
             return globalDb;
         }
     }
 
+    /**
+     * Drop all tables, so we can do a complete clean start
+     * Careful: After executing this method, almost all the managers are in an illegal state, and
+     * can't do any SQL anymore. So take care to actually reinitialize all Managers
+     *
+     * @param c context
+     */
     public static void resetDb(Context c) {
         SQLiteDatabase db = getDb(c);
-        db.execSQL("DROP TABLE IF EXISTS cache");
-        db.execSQL("DROP TABLE IF EXISTS cafeterias");
-        db.execSQL("DROP TABLE IF EXISTS cafeterias_menus");
-        db.execSQL("DROP TABLE IF EXISTS calendar");
-        db.execSQL("DROP TABLE IF EXISTS kalendar_events");
-        db.execSQL("DROP TABLE IF EXISTS locations");
-        db.execSQL("DROP TABLE IF EXISTS news");
-        db.execSQL("DROP TABLE IF EXISTS news_sources");
-        db.execSQL("DROP TABLE IF EXISTS recents");
-        db.execSQL("DROP TABLE IF EXISTS room_locations");
-        db.execSQL("DROP TABLE IF EXISTS syncs");
-        db.execSQL("DROP TABLE IF EXISTS suggestions_lecture");
-        db.execSQL("DROP TABLE IF EXISTS suggestions_mvv");
-        db.execSQL("DROP TABLE IF EXISTS suggestions_persons");
-        db.execSQL("DROP TABLE IF EXISTS suggestions_rooms");
-        db.execSQL("DROP TABLE IF EXISTS unsent_chat_message");
-        db.execSQL("DROP TABLE IF EXISTS chat_message");
-        db.execSQL("DROP TABLE IF EXISTS chat_room");
-        db.execSQL("DROP TABLE IF EXISTS tumLocks");
-        db.execSQL("Drop TABLE IF EXISTS openQuestions");
-        db.execSQL("Drop TABLE IF EXISTS ownQuestions");
-        db.execSQL("DROP TABLE IF EXISTS faculties");
+
+        // Stop all services, since they might have instantiated Managers and cause SQLExceptions
+        Class<?>[] services = new Class<?>[]{
+                CalendarManager.QueryLocationsService.class,
+                SendMessageService.class,
+                SilenceService.class,
+                DownloadService.class,
+                BackgroundService.class};
+        for (Class<?> service : services) {
+            c.stopService(new Intent(c, service));
+        }
+
+        db.beginTransaction();
+        try {
+            db.execSQL("DROP TABLE IF EXISTS cafeterias");
+            db.execSQL("DROP TABLE IF EXISTS cafeterias_menus");
+            db.execSQL("DROP TABLE IF EXISTS calendar");
+            db.execSQL("DROP TABLE IF EXISTS kalendar_events");
+            db.execSQL("DROP TABLE IF EXISTS locations");
+            db.execSQL("DROP TABLE IF EXISTS news");
+            db.execSQL("DROP TABLE IF EXISTS news_sources");
+            db.execSQL("DROP TABLE IF EXISTS recents");
+            db.execSQL("DROP TABLE IF EXISTS room_locations");
+            db.execSQL("DROP TABLE IF EXISTS syncs");
+            db.execSQL("DROP TABLE IF EXISTS suggestions_lecture");
+            db.execSQL("DROP TABLE IF EXISTS suggestions_mvv");
+            db.execSQL("DROP TABLE IF EXISTS suggestions_persons");
+            db.execSQL("DROP TABLE IF EXISTS suggestions_rooms");
+            db.execSQL("DROP TABLE IF EXISTS unsent_chat_message");
+            db.execSQL("DROP TABLE IF EXISTS chat_message");
+            db.execSQL("DROP TABLE IF EXISTS chat_room");
+            db.execSQL("DROP TABLE IF EXISTS tumLocks");
+            db.execSQL("DROP TABLE IF EXISTS openQuestions");
+            db.execSQL("DROP TABLE IF EXISTS ownQuestions");
+            db.execSQL("DROP TABLE IF EXISTS faculties");
+            CacheManager.clearCache(c);
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
     }
 }


### PR DESCRIPTION
moved the cache database to a completely separate database residing in the cache directory.
That also means, deleting all of the cache is as easy as a `rm -r cache` and we'll get no inconsistencies when users clear the cache manually.
<details>
<summary>Shiny new file layout 🎉 </summary>

#### Previously:
```
/data/user/0/de.tum.in.tumcampus
├ cache
│ ├ 1.jpg
│ ├ 2.jpg
│ └ …
└ databases
   └ database.db
```
#### Now: 
```
/data/user/0/de.tum.in.tumcampus
├ cache
│ ├ cache.db
│ ├ 1.jpg
│ ├ 2.jpg
│ └ …
└ databases
   └ database.db
```

</details>

@kordianbruck This probably interferes with your #444 quite a bit, so please take a look… I'm however quite certain, that the objectbox indexing of cached files would also break, if someone manually clears the cache, so this should be the preferred solution.

Also: Resetting the DBs now also stops al Services beforehand, so we don't get strange Exceptions with parallel long running Services

fixes #391 

