### PR TITLE
Add public transport favorites and highlighting

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/TransportationDetailsActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/TransportationDetailsActivity.java
@@ -25,6 +25,7 @@ public class TransportationDetailsActivity extends ActivityForLoadingInBackgroun
 
     private LinearLayout mViewResults;
     private RecentsManager recentsManager;
+    private TransportManager transportManager;
 
     public TransportationDetailsActivity() {
         super(R.layout.activity_transportation_detail);
@@ -36,6 +37,7 @@ public class TransportationDetailsActivity extends ActivityForLoadingInBackgroun
 
         // get all stations from db
         recentsManager = new RecentsManager(this, RecentsManager.STATIONS);
+        transportManager = new TransportManager(this);
         mViewResults = (LinearLayout) this.findViewById(R.id.activity_transport_result);
 
         Intent intent = getIntent();
@@ -93,7 +95,37 @@ public class TransportationDetailsActivity extends ActivityForLoadingInBackgroun
         mViewResults.removeAllViews();
         for (TransportManager.Departure d : result) {
             DepartureView view = new DepartureView(this, true);
-            view.setSymbol(d.symbol);
+
+            view.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    DepartureView departureView = (DepartureView) v;
+                    String symbol = departureView.getSymbol();
+                    boolean highlight;
+                    if (transportManager.isFavorite(symbol)) {
+                        transportManager.deleteFavorite(symbol);
+                        highlight = false;
+                    } else {
+                        transportManager.addFavorite(symbol);
+                        highlight = true;
+                    }
+
+                    // Update the other views with the same symbol
+                    for (int i = 0; i < mViewResults.getChildCount(); i++) {
+                        DepartureView child = (DepartureView) mViewResults.getChildAt(i);
+                        if (child.getSymbol().equals(symbol)) {
+                            child.setSymbol(symbol, highlight);
+                        }
+                    }
+                }
+            });
+
+            if (transportManager.isFavorite(d.symbol)) {
+                view.setSymbol(d.symbol, true);
+            } else {
+                view.setSymbol(d.symbol, false);
+            }
+
             view.setLine(d.direction);
             view.setTime(d.countDown);
             mViewResults.addView(view);

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/TransportationDetailsActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/TransportationDetailsActivity.java
@@ -1,7 +1,10 @@
 package de.tum.in.tumcampusapp.activities;
 
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -50,6 +53,25 @@ public class TransportationDetailsActivity extends ActivityForLoadingInBackgroun
         String locationID = intent.getStringExtra(EXTRA_STATION_ID);
 
         startLoading(location, locationID);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_transport, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_transport_usage) {
+            new AlertDialog.Builder(this)
+                    .setTitle(R.string.transport_action_usage)
+                    .setMessage(R.string.transport_help_text)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .create().show();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/DepartureView.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/DepartureView.java
@@ -94,11 +94,21 @@ public class DepartureView extends LinearLayout {
      * @param symbol Symbol e.g. U6, S1, T14
      */
     @SuppressWarnings("deprecation")
-    public void setSymbol(String symbol) {
+    public void setSymbol(String symbol, boolean highlight) {
         MVVSymbolView d = new MVVSymbolView(symbol);
         mSymbolView.setTextColor(d.getTextColor());
         mSymbolView.setText(symbol);
         mSymbolView.setBackgroundDrawable(d);
+
+        if (highlight) {
+            setBackgroundColor(0x20ffffff & d.getBackgroundColor());
+        } else {
+            setBackgroundColor(d.getTextColor());
+        }
+    }
+
+    public String getSymbol() {
+        return mSymbolView.getText().toString();
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/MVVSymbolView.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/MVVSymbolView.java
@@ -111,6 +111,8 @@ class MVVSymbolView extends Drawable {
         return mTextColor;
     }
 
+    public int getBackgroundColor() { return mBgPaint.getColor(); }
+
     @Override
     public void draw(Canvas canvas) {
         final int width = canvas.getWidth();

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/MVVCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/MVVCard.java
@@ -68,11 +68,16 @@ public class MVVCard extends NotificationAwareCard {
             }
         }
 
+        // Fetch transport favorites, can only be updated in the detailed view
+        TransportManager transportManager = new TransportManager(mContext);
         for (int i = 0; i < mDepartures.size() && i < 5; i++) {
             TransportManager.Departure curr = mDepartures.get(i);
-
             DepartureView view = new DepartureView(mContext);
-            view.setSymbol(curr.symbol);
+            if (transportManager.isFavorite(curr.symbol)) {
+                view.setSymbol(curr.symbol, true);
+            } else {
+                view.setSymbol(curr.symbol, false);
+            }
             view.setLine(curr.direction);
             view.setTime(curr.countDown);
             mLinearLayout.addView(view);

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/AbstractManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/AbstractManager.java
@@ -84,6 +84,7 @@ public class AbstractManager {
             db.execSQL("DROP TABLE IF EXISTS openQuestions");
             db.execSQL("DROP TABLE IF EXISTS ownQuestions");
             db.execSQL("DROP TABLE IF EXISTS faculties");
+            db.execSQL("DROP TABLE IF EXISTS transport_favorites");
             CacheManager.clearCache(c);
             db.setTransactionSuccessful();
         } finally {

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/CardManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/CardManager.java
@@ -122,7 +122,7 @@ public final class CardManager {
 
         // Those don't need TUMOnline access
         managers.add(new CafeteriaManager(context));
-        managers.add(new TransportManager());
+        managers.add(new TransportManager(context));
         managers.add(new NewsManager(context));
 
         for (Card.ProvidesCard manager : managers) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/TransportManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/TransportManager.java
@@ -28,7 +28,7 @@ import de.tum.in.tumcampusapp.cards.generic.Card;
 /**
  * Transport Manager, handles querying data from mvv and card creation
  */
-public class TransportManager implements Card.ProvidesCard {
+public class TransportManager extends AbstractManager implements Card.ProvidesCard {
 
     /*  Documentation for using efa.mvv-muenchen.de
      *
@@ -106,6 +106,39 @@ public class TransportManager implements Card.ProvidesCard {
             departureQuery.append(param).append('&');
         }
         DEPARTURE_QUERY_CONST = departureQuery.toString();
+    }
+
+    public TransportManager(Context context) {
+        super(context);
+
+        // Create table if needed
+        db.execSQL("CREATE TABLE IF NOT EXISTS transport_favorites (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, symbol VARCHAR)");
+    }
+
+    /**
+     * Check if the transport symbol is one of the user's favorites.
+     * @param symbol The transport symbol
+     * @return True, if favorite
+     */
+    public boolean isFavorite(String symbol) {
+        return db.rawQuery("SELECT * FROM transport_favorites WHERE symbol = ?", new String[]{symbol}).getCount() > 0;
+    }
+
+    /**
+     * Adds a transport symbol to the list of the user's favorites.
+     * @param symbol The transport symbol
+     */
+    public void addFavorite(String symbol) {
+        db.execSQL("INSERT INTO transport_favorites (symbol) VALUES (?)", new String[]{symbol});
+    }
+
+    /**
+     * Delete a user's favorite transport symbol.
+     * @param symbol The transport symbol
+     */
+    public void deleteFavorite(String symbol) {
+        db.execSQL("DELETE FROM transport_favorites WHERE symbol = ?", new String[]{symbol});
     }
 
     /**

--- a/app/src/main/res/menu/menu_transport.xml
+++ b/app/src/main/res/menu/menu_transport.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tumcampus="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/action_transport_usage"
+        android:icon="@drawable/ic_action_about"
+        android:title="@string/transport_action_usage"
+        tumcampus:showAsAction="always" />
+
+</menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -423,4 +423,7 @@ Signatur: %5$s</string>
     <string name="wifi_identity_zone">Identität enthält keine Zone</string>
     <string name="wifi_dns_name_not_set">DNS-Name ist nicht festgelegt</string>
     <string name="wifi_anonymous_identity_not_set">Anonyme Identität nicht korrekt</string>
+
+    <string name="transport_action_usage">Hilfestellung</string>
+    <string name="transport_help_text">Tippe deine favorisierten Verkehrslinien an um sie hervorzuheben. Tippe erneut und sie sind wieder normal.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -496,6 +496,9 @@ Signature: %5$s</string>
     <string name="wifi_dns_name_not_set">DNS Name is not set</string>
     <string name="wifi_identity_zone">Identity does not contain zone</string>
     <string name="wifi_anonymous_identity_not_set">Anonymous Identity not correct</string>
+
+    <string name="transport_action_usage">Usage</string>
+    <string name="transport_help_text">Tap your favorite transportation lines to highlight them. Tap again to revert them back to normal.</string>
 </resources>
 
 


### PR DESCRIPTION
## Issue
This change adds user customizable highlighting of public transport lines. In the detailed view, you can tap the transport lines you want to track. It is a lightweight visual aid that is in my opinion more intuitive than selective filtering.
This fixes the following issue(s): #430 

## Screenshot
![screenshot_1493809703](https://cloud.githubusercontent.com/assets/3391295/25658578/e3286144-3003-11e7-9980-ba6bad4c33a6.png)
![screenshot_1493809708](https://cloud.githubusercontent.com/assets/3391295/25658581/e62129b2-3003-11e7-9803-957994d67855.png)
![screenshot_1493809714](https://cloud.githubusercontent.com/assets/3391295/25658587/e88b71a8-3003-11e7-9cbc-ccca474d42ed.png)

## Why this is useful for all students
The user can highlight his most used public transportation lines. This helps to track the latest departures he cares about.