### PR TITLE
Simplify the usage of stickylistheader

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/adapters/LecturesListAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/adapters/LecturesListAdapter.java
@@ -22,44 +22,22 @@ import se.emilsjolander.stickylistheaders.StickyListHeadersAdapter;
  * show semester info as sticky header.
  */
 
-public class LecturesListAdapter extends BaseAdapter implements StickyListHeadersAdapter {
-
-    private static List<LecturesSearchRow> lecturesList;
-    private final List<String> filters;
-    private final LayoutInflater mInflater;
-    private final Context context;
+public class LecturesListAdapter extends SimpleStickyListHeadersAdapter<LecturesSearchRow> {
 
     public static LecturesListAdapter newInstance(Context context, List<LecturesSearchRow> results) {
-        lecturesList = results;
-        return new LecturesListAdapter(context);
+        return new LecturesListAdapter(context, results);
     }
 
-    private LecturesListAdapter(Context context) {
-        this.context = context;
-        mInflater = LayoutInflater.from(context);
-
-        filters = new ArrayList<>();
-        for (LecturesSearchRow result : lecturesList) {
-            String item = result.getSemester_id();
-            if (!filters.contains(item)) {
-                filters.add(item);
-            }
-        }
+    private LecturesListAdapter(Context context, List<LecturesSearchRow> results) {
+        super(context, results);
     }
 
     @Override
-    public int getCount() {
-        return lecturesList.size();
-    }
-
-    @Override
-    public Object getItem(int position) {
-        return lecturesList.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
+    String genenrateHeaderName(LecturesSearchRow item) {
+        String headerText = super.genenrateHeaderName(item);
+        headerText = headerText.replaceAll("Sommersemester", this.context.getString(R.string.semester_summer));
+        headerText = headerText.replaceAll("Wintersemester", this.context.getString(R.string.semester_winter));
+        return headerText;
     }
 
     @Override
@@ -83,7 +61,7 @@ public class LecturesListAdapter extends BaseAdapter implements StickyListHeader
             holder = (ViewHolder) convertView.getTag();
         }
 
-        LecturesSearchRow lvItem = lecturesList.get(position);
+        LecturesSearchRow lvItem = infoList.get(position);
 
         // if we have something to display - set for each lecture element
         if (lvItem != null) {
@@ -95,41 +73,10 @@ public class LecturesListAdapter extends BaseAdapter implements StickyListHeader
         return convertView;
     }
 
-    // Generate header view
-    @Override
-    public View getHeaderView(int pos, View view, ViewGroup parent) {
-        HeaderViewHolder holder;
-        View convertView = view;
-        if (convertView == null) {
-            holder = new HeaderViewHolder();
-            convertView = mInflater.inflate(R.layout.header, parent, false);
-            holder.text = (TextView) convertView.findViewById(R.id.lecture_header);
-            convertView.setTag(holder);
-        } else {
-            holder = (HeaderViewHolder) convertView.getTag();
-        }
-        //set header text as first char in name
-        String headerText = lecturesList.get(pos).getSemester_name();
-        headerText = headerText.replaceAll("Sommersemester", this.context.getString(R.string.semester_summer));
-        headerText = headerText.replaceAll("Wintersemester", this.context.getString(R.string.semester_winter));
-
-        holder.text.setText(headerText);
-        return convertView;
-    }
-
-    @Override
-    public long getHeaderId(int i) {
-        return filters.indexOf(lecturesList.get(i).getSemester_id());
-    }
-
     // the layout of the list
     static class ViewHolder {
         TextView tvDozent;
         TextView tvLectureName;
         TextView tvTypeSWSSemester;
-    }
-
-    static class HeaderViewHolder {
-        TextView text;
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/adapters/SimpleStickyListHeadersAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/adapters/SimpleStickyListHeadersAdapter.java
@@ -1,0 +1,117 @@
+package de.tum.in.tumcampusapp.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.tum.in.tumcampusapp.R;
+import se.emilsjolander.stickylistheaders.StickyListHeadersAdapter;
+
+/**
+ * An abstract StickyListHeadersAdapter helps to reduce redundant work for using StickyListHeaders.
+ * It implements some method requred by StickyListHeadersAdapter, including getHeaderView getHeaderId,
+ * getCount, getItem and getItemId.
+ * By extending this class, only getView need to implement.
+ * On the other hand this class requires the data model implementing its interface to get header name and id.
+ * @param <T> The model of data
+ */
+abstract public class SimpleStickyListHeadersAdapter<T extends SimpleStickyListHeadersAdapter.SimpleStickyListItem>
+        extends BaseAdapter implements StickyListHeadersAdapter {
+    List<T> infoList;
+    Context context;
+    private final List<String> filters;
+    final LayoutInflater mInflater;
+
+    SimpleStickyListHeadersAdapter(Context context, List<T> infos){
+        this.context = context;
+        this.infoList = infos;
+        this.mInflater = LayoutInflater.from(context);
+
+        filters = new ArrayList<>();
+        for (T result : infoList) {
+            String item = result.getHeaderId();
+            if (!filters.contains(item)) {
+                filters.add(item);
+            }
+        }
+    }
+
+    // getView mtehod need to be implemented by subclass
+    @Override
+    abstract public View getView(int position, View convertView, ViewGroup parent);
+
+    public List<T> getInfoList(){
+        return infoList;
+    }
+
+    public LayoutInflater getInflater() {
+        return mInflater;
+    }
+
+    /**
+     * Genernate header for this item.
+     * This methoded can be override if header name need to be modified.
+     * @param item the item
+     * @return the header for this item
+     */
+    String genenrateHeaderName(T item){
+        return item.getHeadName();
+    }
+
+    @Override
+    public View getHeaderView(int position, View convertView, ViewGroup partent) {
+        HeaderViewHolder holder;
+        View view = convertView;
+
+        if (view == null) {
+            holder = new HeaderViewHolder();
+            view = mInflater.inflate(R.layout.header, partent, false);
+            holder.text = (TextView) view.findViewById(R.id.lecture_header);
+            view.setTag(holder);
+        } else {
+            holder = (HeaderViewHolder) view.getTag();
+        }
+
+        String headerText = genenrateHeaderName(infoList.get(position));
+        holder.text.setText(headerText);
+
+        return view;
+    }
+
+
+    @Override
+    public long getHeaderId(int i) {
+        return filters.indexOf(infoList.get(i).getHeaderId());
+    }
+
+    @Override
+    public int getCount() {
+        return infoList.size();
+    }
+
+    @Override
+    public Object getItem(int position) {
+        return infoList.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    // Header view
+    private static class HeaderViewHolder {
+        TextView text;
+    }
+
+    public interface SimpleStickyListItem {
+        String getHeadName();
+        String getHeaderId();
+    }
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/LecturesSearchRow.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/LecturesSearchRow.java
@@ -5,6 +5,8 @@ import android.support.annotation.NonNull;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
+import de.tum.in.tumcampusapp.adapters.SimpleStickyListHeadersAdapter;
+
 /**
  * This class is dealing with the deserialization of the output of TUMOnline to
  * the method "sucheLehrveranstaltungen".
@@ -12,7 +14,8 @@ import org.simpleframework.xml.Root;
  */
 
 @Root(name = "row")
-public class LecturesSearchRow implements Comparable<LecturesSearchRow> {
+public class LecturesSearchRow
+        implements Comparable<LecturesSearchRow>, SimpleStickyListHeadersAdapter.SimpleStickyListItem{
 
     public static final String STP_SP_NR = "stp_sp_nr";
 
@@ -143,5 +146,15 @@ public class LecturesSearchRow implements Comparable<LecturesSearchRow> {
     @Override
     public int compareTo(@NonNull LecturesSearchRow lecturesSearchRow) {
         return lecturesSearchRow.getSemester_id().compareTo(semester_id);
+    }
+
+    @Override
+    public String getHeadName() {
+        return getSemester_name();
+    }
+
+    @Override
+    public String getHeaderId() {
+        return getSemester_id();
     }
 }


### PR DESCRIPTION
It reduces the work of creating adapter for stickylistheader.
Currently it is not easy to reuse.