### PR TITLE
fix IllegalArgumentException in getOkHttpResponse

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/NetUtils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/NetUtils.java
@@ -87,7 +87,7 @@ public class NetUtils {
     private Optional<ResponseBody> getOkHttpResponse(String url) throws IOException {
         // if we are not online, fetch makes no sense
         boolean isOnline = isConnected(mContext);
-        if (!isOnline || url == null) {
+        if (!isOnline || url == null || url.equals("null")) {
             return Optional.absent();
         }
 


### PR DESCRIPTION
sometimes, we accidentally pass "null" as a String, which didn't get handled, yet