### PR TITLE
Upgrade dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,25 +3,21 @@ apply from: '../findbugs.gradle'
 apply from: '../pmd.gradle'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
     buildTypes {
         all {
             proguardFiles(file('../proguard').listFiles())
             proguardFile getDefaultProguardFile('proguard-android.txt')
             minifyEnabled true
         }
-        debug {
-            debuggable true
-        }
-        release {
-            debuggable false
-        }
+        debug.debuggable true
+        release.debuggable false
     }
     defaultConfig {
         applicationId "de.tum.in.tumcampus"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 99999
         versionName "1.4.10-dev"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -45,36 +41,34 @@ android {
     publishNonDefault true
 }
 
-def androidSupportVersion = '25.3.1'
+def androidSupportVersion = '26.0.0'
 def retrofitVersion = '2.2.0'
 def espressoVersion = '2.2.2'
 
 configurations.all {
     resolutionStrategy {
         force "com.android.support:design:$androidSupportVersion"
-        force "com.android.support:recyclerview-v7:$androidSupportVersion"
         force 'com.google.code.findbugs:jsr305:3.0.1'
     }
 }
-
 
 dependencies {
     compile "com.android.support:cardview-v7:$androidSupportVersion"
     compile "com.android.support:design:$androidSupportVersion"
     compile "com.android.support:preference-v7:$androidSupportVersion"
-    compile 'com.google.android.gms:play-services-gcm:10.2.1'
-    compile 'com.google.code.gson:gson:2.8.0'
-    compile 'com.google.guava:guava:20.0'
+    compile 'com.google.android.gms:play-services-gcm:11.0.2'
+    compile 'com.google.code.gson:gson:2.8.1'
+    compile 'com.google.guava:guava:22.0-android'
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     compile 'com.github.chrisbanes:PhotoView:1.3.0'
-    compile 'me.dm7.barcodescanner:zxing:1.9'
+    compile 'me.dm7.barcodescanner:zxing:1.9.4'
     compile('org.simpleframework:simple-xml:2.7.1') {
         exclude group: 'stax', module: 'stax-api'
         exclude group: 'xpp3', module: 'xpp3'
     }
-    compile 'de.psdev.licensesdialog:licensesdialog:1.8.2'
+    compile 'de.psdev.licensesdialog:licensesdialog:1.8.3'
     compile 'com.github.alamkanak:android-week-view:1.2.6'
     compile 'de.hdodenhof:circleimageview:2.1.0'
     compile 'net.danlew:android.joda:2.9.9'

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/ChatActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/ChatActivity.java
@@ -1,5 +1,6 @@
 package de.tum.in.tumcampusapp.activities;
 
+import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.NotificationManager;
 import android.app.Service;
@@ -11,8 +12,10 @@ import android.content.IntentFilter;
 import android.database.Cursor;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.support.v4.app.RemoteInput;
 import android.support.v4.content.LocalBroadcastManager;
@@ -190,13 +193,23 @@ public class ChatActivity extends AppCompatActivity implements DialogInterface.O
                 mediaPlayer.start();
             } else if (am.getRingerMode() == AudioManager.RINGER_MODE_VIBRATE) { //Possibly only vibration is enabled
                 Vibrator v = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
-                v.vibrate(500);
+                vibrate(v);
             }
         }
 
         //Update the history
         chatHistoryAdapter.changeCursor(chatManager.getAll());
 
+    }
+
+    @SuppressWarnings("deprecation")
+    @TargetApi(android.os.Build.VERSION_CODES.O)
+    private static void vibrate(Vibrator v) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            v.vibrate(VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE));
+        } else {
+            v.vibrate(500);
+        }
     }
 
     @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/StartupActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/StartupActivity.java
@@ -3,6 +3,9 @@ package de.tum.in.tumcampusapp.activities;
 import android.animation.Animator;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -10,6 +13,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
@@ -136,6 +140,8 @@ public class StartupActivity extends AppCompatActivity {
 
         //Request Permissions for Android 6.0
         requestLocationPermission();
+
+        setupNotificationChannels();
     }
 
     @Override
@@ -304,6 +310,19 @@ public class StartupActivity extends AppCompatActivity {
             e.putBoolean(Const.HIDE_WIZARD_ON_STARTUP, sp.getBoolean("hide_wizzard_on_startup", false));
             e.remove("hide_wizzard_on_startup");
             e.apply();
+        }
+    }
+
+    /**
+     * implement proper NotificationChannels? This just creates a default one, so Notifications get shown at all on Android O
+     */
+    @TargetApi(Build.VERSION_CODES.O)
+    private void setupNotificationChannels() {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.createNotificationChannel(
+                    new NotificationChannel(Const.NOTIFICATION_CHANNEL_DEFAULT, Const.NOTIFICATION_CHANNEL_DEFAULT, NotificationManager.IMPORTANCE_DEFAULT));
         }
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/generic/ActivityForSearching.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/generic/ActivityForSearching.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.content.SearchRecentSuggestionsProvider;
 import android.database.Cursor;
 import android.provider.SearchRecentSuggestions;
-import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.SearchView;
 import android.view.Menu;
@@ -76,7 +75,7 @@ public abstract class ActivityForSearching extends ProgressActivity {
 
         // Get SearchView
         mSearchItem = menu.findItem(R.id.action_search);
-        mSearchView = (SearchView) MenuItemCompat.getActionView(mSearchItem);
+        mSearchView = (SearchView) mSearchItem.getActionView();
 
         // Set the searchable configuration
         SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
@@ -112,14 +111,14 @@ public abstract class ActivityForSearching extends ProgressActivity {
         mSearchView.setOnCloseListener(new SearchView.OnCloseListener() {
             @Override
             public boolean onClose() {
-                MenuItemCompat.collapseActionView(mSearchItem);
+                mSearchItem.collapseActionView();
                 mQuery = null;
                 onStartSearch();
                 return false;
             }
         });
 
-        MenuItemCompat.setOnActionExpandListener(mSearchItem, new MenuItemCompat.OnActionExpandListener() {
+        mSearchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem item) {
                 return true;
@@ -138,8 +137,8 @@ public abstract class ActivityForSearching extends ProgressActivity {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         if (mOpenSearch) {
-            MenuItemCompat.setShowAsAction(mSearchItem, MenuItemCompat.SHOW_AS_ACTION_ALWAYS | MenuItemCompat.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
-            MenuItemCompat.expandActionView(mSearchItem);
+            mSearchItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS | MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
+            mSearchItem.expandActionView();
             return true;
         }
         return super.onPrepareOptionsMenu(menu);

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Const.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Const.java
@@ -120,6 +120,8 @@ public final class Const {
     public static final String URL_MAP_IMAGE = "https://" + API_HOSTNAME+ URL_ROOM_FINDER_API + "map/";
     public static final String ROOM_ID = "room_id";
 
+    public static final String NOTIFICATION_CHANNEL_DEFAULT = "default";
+
     private Const() {
         // Const is a utility class
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/NetUtils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/NetUtils.java
@@ -189,7 +189,7 @@ public class NetUtils {
                 }
             }
 
-            file = Optional.of(mContext.getCacheDir().getAbsolutePath() + '/' + Utils.md5(url) + ".jpg");
+            file = Optional.of(mContext.getCacheDir().getAbsolutePath() + '/' + Utils.hash(url) + ".jpg");
             File f = new File(file.get());
             downloadToFile(url, file.get());
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Utils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Utils.java
@@ -30,7 +30,6 @@ import java.io.StringWriter;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -256,13 +255,13 @@ public final class Utils {
     }
 
     /**
-     * Get md5 hash from string
+     * Get a persistent hash from string
      *
      * @param str String to hash
-     * @return md5 hash as string
+     * @return hash hash as string
      */
-    public static String md5(String str) {
-        return Hashing.md5().hashBytes(str.getBytes(Charsets.UTF_8)).toString();
+    public static String hash(String str) {
+        return Hashing.murmur3_128().hashBytes(str.getBytes(Charsets.UTF_8)).toString();
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/CafeteriaMenuCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/CafeteriaMenuCard.java
@@ -136,7 +136,7 @@ public class CafeteriaMenuCard extends NotificationAwareCard {
                 continue;
             }
 
-            NotificationCompat.Builder pageNotification = new NotificationCompat.Builder(mContext).setContentTitle(PATTERN.matcher(menu.typeLong).replaceAll("").trim());
+            NotificationCompat.Builder pageNotification = new NotificationCompat.Builder(mContext, Const.NOTIFICATION_CHANNEL_DEFAULT).setContentTitle(PATTERN.matcher(menu.typeLong).replaceAll("").trim());
 
             StringBuilder content = new StringBuilder(menu.name);
             if (rolePrices.containsKey(menu.typeLong)) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/MVVCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/MVVCard.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.activities.TransportationDetailsActivity;
+import de.tum.in.tumcampusapp.auxiliary.Const;
 import de.tum.in.tumcampusapp.auxiliary.DepartureView;
 import de.tum.in.tumcampusapp.cards.generic.Card;
 import de.tum.in.tumcampusapp.cards.generic.NotificationAwareCard;
@@ -122,7 +123,7 @@ public class MVVCard extends NotificationAwareCard {
             }
 
             NotificationCompat.Builder pageNotification =
-                    new NotificationCompat.Builder(mContext)
+                    new NotificationCompat.Builder(mContext, Const.NOTIFICATION_CHANNEL_DEFAULT)
                             .setContentTitle(d.countDown + "min")
                             .setContentText(d.servingLine + " " + d.direction);
             morePageNotification.addPage(pageNotification.build());

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/generic/NotificationAwareCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/generic/NotificationAwareCard.java
@@ -9,6 +9,7 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 
 import de.tum.in.tumcampusapp.R;
+import de.tum.in.tumcampusapp.auxiliary.Const;
 
 public abstract class NotificationAwareCard extends Card {
     public NotificationAwareCard(int cardType, Context context, String settings) {
@@ -35,7 +36,7 @@ public abstract class NotificationAwareCard extends Card {
     private void notifyUser() {
         // Start building our notification
         NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(mContext)
+                new NotificationCompat.Builder(mContext, Const.NOTIFICATION_CHANNEL_DEFAULT)
                         .setAutoCancel(true)
                         .setContentTitle(getTitle());
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/EduroamManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/EduroamManager.java
@@ -118,8 +118,7 @@ public class EduroamManager {
             return false;
         }
 
-        //Save, enable and exit
-        wifiManager.saveConfiguration();
+        //Enable and exit
         wifiManager.enableNetwork(networkId, true);
         return true;
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/notifications/Alarm.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/notifications/Alarm.java
@@ -28,6 +28,7 @@ import de.tum.in.tumcampusapp.auxiliary.RSASigner;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.models.gcm.GCMAlert;
 import de.tum.in.tumcampusapp.models.gcm.GCMNotification;
+import de.tum.in.tumcampusapp.auxiliary.Const;
 
 public class Alarm extends GenericNotification {
 
@@ -144,7 +145,7 @@ public class Alarm extends GenericNotification {
         PendingIntent pending = PendingIntent.getActivity(this.context, 0, alarm, PendingIntent.FLAG_UPDATE_CURRENT);
         String strippedDescription = Utils.stripHtml(info.getDescription()); // Strip any html tags from the description
 
-        return new NotificationCompat.Builder(context)
+        return new NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_DEFAULT)
                 .setSmallIcon(this.icon)
                 .setContentTitle(info.getTitle())
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(strippedDescription))

--- a/app/src/main/java/de/tum/in/tumcampusapp/notifications/Chat.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/notifications/Chat.java
@@ -152,7 +152,7 @@ public class Chat extends GenericNotification {
                             .build();
 
             //Create a nice notification
-            return new NotificationCompat.Builder(context)
+            return new NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_DEFAULT)
                     .setSmallIcon(this.icon)
                     .setContentTitle(chatRoom.getName().substring(4))
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(notificationText))

--- a/app/src/main/java/de/tum/in/tumcampusapp/notifications/Update.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/notifications/Update.java
@@ -19,6 +19,7 @@ import de.tum.in.tumcampusapp.api.TUMCabeClient;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.models.gcm.GCMNotification;
 import de.tum.in.tumcampusapp.models.gcm.GCMUpdate;
+import de.tum.in.tumcampusapp.auxiliary.Const;
 
 public class Update extends GenericNotification {
 
@@ -78,7 +79,7 @@ public class Update extends GenericNotification {
             title = info.getTitle();
         }
 
-        return new NotificationCompat.Builder(context)
+        return new NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_DEFAULT)
                 .setSmallIcon(this.icon)
                 .setContentTitle(title)
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(description))

--- a/app/src/main/java/de/tum/in/tumcampusapp/services/FavoriteDishService.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/services/FavoriteDishService.java
@@ -35,7 +35,7 @@ public class FavoriteDishService extends IntentService {
                 Intent intent = new Intent(this, CafeteriaActivity.class);
                 intent.putExtra(Const.MENSA_FOR_FAVORITEDISH, c.getInt(1));
                 PendingIntent pi = PendingIntent.getActivity(this, index, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-                NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this)
+                NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this, "default")
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Your Favorite Dish!")
                         .setContentText(c.getString(0))

--- a/app/src/main/java/de/tum/in/tumcampusapp/services/ScanResultsAvailableReceiver.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/services/ScanResultsAvailableReceiver.java
@@ -25,6 +25,7 @@ import de.tum.in.tumcampusapp.auxiliary.WifiMeasurementLocationListener;
 import de.tum.in.tumcampusapp.managers.EduroamManager;
 import de.tum.in.tumcampusapp.managers.WifiMeasurementManager;
 import de.tum.in.tumcampusapp.models.tumcabe.WifiMeasurement;
+import de.tum.in.tumcampusapp.auxiliary.Const;
 
 /**
  * Listens for android's ScanResultsAvailable broadcast and checks if eduroam is nearby.
@@ -141,7 +142,7 @@ public class ScanResultsAvailableReceiver extends BroadcastReceiver {
         PendingIntent hideIntent = PendingIntent.getService(context, 0, hide, PendingIntent.FLAG_UPDATE_CURRENT);
 
         // Create GCMNotification using NotificationCompat.Builder
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_DEFAULT)
                 .setSmallIcon(R.drawable.ic_notification_wifi)
                 .setTicker(context.getString(R.string.setup_eduroam))
                 .setContentTitle(context.getString(R.string.setup_eduroam))

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,7 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -23,5 +21,6 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
+        maven { url 'https://maven.google.com' }
     }
 }


### PR DESCRIPTION
Upgrade to API 26 and fix the usual subsequent deprecation warnings

Testing with Android O devices / emulators for regressions would be much appreciated, but on my emulator everything seems to work fine.

@kordianbruck I changed the hash algorithm for the cache in 57d91fb, so we might wanna issue a cache cleaning on app upgrade
