### PR TITLE
Only show stations instead of any type (including addresses etc.) in MVV search

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/TransportManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/TransportManager.java
@@ -72,7 +72,7 @@ public class TransportManager extends AbstractManager implements Card.ProvidesCa
     private static final String STATELESS = "stateless=1";
     private static final String COORD_OUTPUT_FORMAT = "coordOutputFormat=WGS84";
     private static final String LOCATION_SERVER = "locationServerActive=1";
-    private static final String STATION_SEARCH_TYPE = "type_sf=any";
+    private static final String STATION_SEARCH_TYPE = "type_sf=stop";
     private static final String STATION_SEARCH_TYPE_COORD = "type_sf=coord";
     private static final String STATION_SEARCH_COMMON = "anyObjFilter_sf=126&reducedAnyPostcodeObjFilter_sf=64&reducedAnyTooManyObjFilter_sf=2&useHouseNumberList=true";
     private static final String STATION_SEARCH_HITLIST_SIZE = "anyMaxSizeHitList=10"; // 10 <=> what we can display on one page


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #480

## Why this is useful for all students

In the current version, it only shows every possible match returned by the Elektronische Fahrplanauskunft of the MVV. Some of the items are addresses and points of interest that do not have departure plan attached to them. By changing the search type from *any* to *stop* we only search for real stations (like Theresienstraße or Untere Strassäcker). These stations are guaranteed to have a departure plan attached (so no more bad results and blank screens).