### PR TITLE
Don't show TUMOnline error when valid empty response is returned

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/GradesActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/GradesActivity.java
@@ -346,6 +346,11 @@ public class GradesActivity extends ActivityForAccessingTumOnline<ExamList> {
     }
 
     @Override
+    public void onNoDataToShow(){
+        showError(R.string.no_grades);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         Intent intent;
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/generic/ActivityForAccessingTumOnline.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/generic/ActivityForAccessingTumOnline.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.widget.SwipeRefreshLayout;
 
+import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.auxiliary.Const;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.tumonline.TUMOnlineConst;
@@ -103,4 +104,8 @@ public abstract class ActivityForAccessingTumOnline<T> extends ProgressActivity 
         requestFetch(true);
     }
 
+    @Override
+    public void onNoDataToShow(){
+        showError(R.string.no_data_to_show);
+    }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/generic/ActivityForSearchingTumOnline.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/generic/ActivityForSearchingTumOnline.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.widget.SwipeRefreshLayout;
 
+import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.auxiliary.Const;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.tumonline.TUMOnlineConst;
@@ -119,5 +120,10 @@ public abstract class ActivityForSearchingTumOnline<T> extends ActivityForSearch
     @Override
     public void onRefresh() {
         requestFetch(true);
+    }
+
+    @Override
+    public void onNoDataToShow(){
+        showError(R.string.no_data_to_show);
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/TumManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/TumManager.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import de.tum.in.tumcampusapp.auxiliary.DateUtils;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.models.tumo.Error;
+import de.tum.in.tumcampusapp.tumonline.TUMOnlineRequest;
 
 /**
  * TUMOnline lock manager: prevent too many requests send to TUMO
@@ -110,14 +111,16 @@ public class TumManager extends AbstractManager {
         //Try to parse the error
         String msg = "";
         try {
-
+            if(data.contains(TUMOnlineRequest.NO_ENTRIES)){
+                return data;
+            }
             Error res = new Persister().read(Error.class, data);
             msg = res.getMessage();
         } catch (Exception e) {
             Utils.log(e);
         }
 
-        //Enter it into the Databse
+        //Enter it into the Database
         db.execSQL("REPLACE INTO tumLocks (url, error, timestamp, lockedFor, active) VALUES (?, ?, datetime('now'), ?, 1)", new String[]{url, msg, String.valueOf(lockTime)});
 
         return msg;

--- a/app/src/main/java/de/tum/in/tumcampusapp/tumonline/TUMOnlineRequest.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/tumonline/TUMOnlineRequest.java
@@ -39,6 +39,11 @@ public final class TUMOnlineRequest<T> {
     private static final String NO_FUNCTION_RIGHTS = "Keine Rechte für Funktion";
 
     /**
+     * Valid response (no TUMOnline error) but no data available (e.g. no grades yet)
+     * */
+    public static final String NO_ENTRIES = "<rowset>\n</rowset>";
+
+    /**
      * String possibly contained in response from server
      */
     private static final String TOKEN_NOT_CONFIRMED = "Token ist nicht bestätigt oder ungültig!";
@@ -222,6 +227,11 @@ public final class TUMOnlineRequest<T> {
 
                 //Check for common errors
                 if (!result.isPresent()) {
+                    if(lastError.contains(NO_ENTRIES)){
+                        listener.onNoDataToShow();
+                        return;
+                    }
+
                     String error;
                     if (lastError.contains(TOKEN_NOT_CONFIRMED)) {
                         error = context.getString(R.string.dialog_access_token_invalid);

--- a/app/src/main/java/de/tum/in/tumcampusapp/tumonline/TUMOnlineRequestFetchListener.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/tumonline/TUMOnlineRequestFetchListener.java
@@ -34,4 +34,9 @@ public interface TUMOnlineRequestFetchListener<T> {
 	 */
 	void onFetchError(String errorReason);
 
+	/**
+	 * Called if there was no error accessing tum online but there are no results to show (no entries)
+	 */
+	void onNoDataToShow();
+
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -37,6 +37,7 @@
     <string name="dialog_access_token_invalid">TUMonline-Access-Token nicht aktiviert</string>
     <string name="dialog_no_rights_function">Keine Rechte für diese Funktion</string>
     <string name="empty_result">Die Anfrage lieferte ein fehlerhaftes Ergebnis</string>
+    <string name="no_data_to_show">Es sind keine Daten vorhanden.</string>
 
     <!-- Exam/Grades -->
     <string name="average_grade">Durchschnittsnote</string>
@@ -48,6 +49,7 @@
     <string name="mode">Modus</string>
     <string name="all_programs">Alle Programme</string>
     <string name="date">Datum</string>
+    <string name="no_grades">Du hast noch keine Noten, die angezeigt werden könnten.</string>
 
     <!-- Preferences -->
     <string name="lrz_id">TUM Kennung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="dialog_access_token_invalid">TUMonline-Access-Token not enabled</string>
     <string name="dialog_no_rights_function">No rights to access this function</string>
     <string name="empty_result">The operation delivered a faulty result</string>
+    <string name="no_data_to_show">There is no data to show.</string>
 
     <!-- Exam/Grades -->
     <string name="average_grade">Average grade</string>
@@ -57,6 +58,7 @@
     <string name="all_programs">All programs</string>
     <string name="date">Date</string>
     <string name="credits" translatable="false">ECTS</string>
+    <string name="no_grades">You don\'t have any grades yet.</string>
 
     <!-- Preferences -->
     <string name="lrz_id">TUM Identification</string>


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #526 

## Screenshot
![no_grades_error](https://user-images.githubusercontent.com/16260112/31728645-26f32d66-b42d-11e7-9d21-682f27f076de.png)

## Why this is useful for all students
Students won't be confused by wrong error message