### PR TITLE
Update build files for AndroidStudio 3.0 / API 27

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,8 +3,8 @@ apply from: '../findbugs.gradle'
 apply from: '../pmd.gradle'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     buildTypes {
         all {
             proguardFiles(file('../proguard').listFiles())
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         applicationId "de.tum.in.tumcampus"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 99999
         versionName "1.4.10-dev"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -41,7 +41,7 @@ android {
     publishNonDefault true
 }
 
-def androidSupportVersion = '26.1.0'
+def androidSupportVersion = '27.0.0'
 def retrofitVersion = '2.3.0'
 def espressoVersion = '3.0.1'
 def firebaseVersion = '11.4.2'
@@ -54,35 +54,35 @@ configurations.all {
 }
 
 dependencies {
-    compile "com.android.support:cardview-v7:$androidSupportVersion"
-    compile "com.android.support:design:$androidSupportVersion"
-    compile "com.android.support:preference-v7:$androidSupportVersion"
-    compile "com.google.android.gms:play-services-base:$firebaseVersion"
-    compile "com.google.firebase:firebase-messaging:$firebaseVersion"
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.google.guava:guava:22.0-android'
-    compile 'se.emilsjolander:stickylistheaders:2.7.0'
-    compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
-    compile 'com.github.chrisbanes:PhotoView:1.3.0'
-    compile 'me.dm7.barcodescanner:zxing:1.9.8'
-    compile('org.simpleframework:simple-xml:2.7.1') {
+    implementation "com.android.support:cardview-v7:$androidSupportVersion"
+    implementation "com.android.support:design:$androidSupportVersion"
+    implementation "com.android.support:preference-v7:$androidSupportVersion"
+    implementation "com.google.android.gms:play-services-base:$firebaseVersion"
+    implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.guava:guava:23.2-android'
+    implementation 'se.emilsjolander:stickylistheaders:2.7.0'
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    implementation 'com.github.chrisbanes:PhotoView:1.3.0'
+    implementation 'me.dm7.barcodescanner:zxing:1.9.8'
+    implementation('org.simpleframework:simple-xml:2.7.1') {
         exclude group: 'stax', module: 'stax-api'
         exclude group: 'xpp3', module: 'xpp3'
     }
-    compile 'de.psdev.licensesdialog:licensesdialog:1.8.3'
-    compile 'com.github.alamkanak:android-week-view:1.2.6'
-    compile 'de.hdodenhof:circleimageview:2.2.0'
-    compile 'net.danlew:android.joda:2.9.9'
-    compile 'com.github.franmontiel:PersistentCookieJar:v1.0.0'
-    compile 'com.github.barteksc:android-pdf-viewer:2.5.1'
+    implementation 'de.psdev.licensesdialog:licensesdialog:1.8.3'
+    implementation 'com.github.alamkanak:android-week-view:1.2.6'
+    implementation 'de.hdodenhof:circleimageview:2.2.0'
+    implementation 'net.danlew:android.joda:2.9.9'
+    implementation 'com.github.franmontiel:PersistentCookieJar:v1.0.0'
+    implementation 'com.github.barteksc:android-pdf-viewer:2.5.1'
 
-    androidTestCompile "com.android.support:support-annotations:$androidSupportVersion"
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
-    androidTestCompile "com.android.support.test.espresso:espresso-core:$espressoVersion"
-    androidTestCompile "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
+    androidTestImplementation "com.android.support:support-annotations:$androidSupportVersion"
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
+    androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/res/drawable/star_selected.xml
+++ b/app/src/main/res/drawable/star_selected.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="@color/star_selected"
+        android:fillColor="#ffd600"
         android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
 </vector>

--- a/app/src/main/res/drawable/star_unselected.xml
+++ b/app/src/main/res/drawable/star_unselected.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="@color/star_unselected"
+        android:fillColor="#C0C0C0"
         android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
 </vector>

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        google()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.google.gms:google-services:3.1.1'
     }
 }
@@ -17,11 +18,12 @@ allprojects {
         options.fork = true  // Fork your compilation into a child process
         options.forkOptions.setMemoryMaximumSize("4g") // Set maximum memory to 4g
         options.compilerArgs << "-Xlint:all"
+        options.compilerArgs << "-Xlint:-classfile"
         options.compilerArgs << "-Werror"
     }
     repositories {
         jcenter()
+        google()
         maven { url "https://jitpack.io" }
-        maven { url 'https://maven.google.com' }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 31 18:11:27 CEST 2017
+#Thu Oct 26 10:39:02 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Java8 language features and Kotlin. :tada: 

I updated the build tools and included googles maven repo.
Unfortunately, I also had to fix some build errors, like suppression of `classfile` warnings and hard-coding the colors in some drawables. Though, this shouldn't make any observable difference.

For the gradle files, I followed [Googles migration guidelines](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html)