### PR TITLE
Pfent/fix554

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply from: '../pmd.gradle'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.1'
     buildTypes {
         all {
             proguardFiles(file('../proguard').listFiles())

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/wizard/WizNavCheckTokenActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/wizard/WizNavCheckTokenActivity.java
@@ -98,10 +98,14 @@ public class WizNavCheckTokenActivity extends ActivityForLoadingInBackground<Voi
                     .toString());
 
             // Save the TUMOnline id to preferences
-            Utils.setSetting(this, Const.TUMO_PIDENT_NR, identity.getObfuscatd_ids().getStudierende()); // Switch to identity.getObfuscatd_id() in the future
-            Utils.setSetting(this, Const.TUMO_STUDENT_ID, identity.getObfuscatd_ids().getStudierende());
-            Utils.setSetting(this, Const.TUMO_EXTERNAL_ID, identity.getObfuscatd_ids().getExtern());
-            Utils.setSetting(this, Const.TUMO_EMPLOYEE_ID, identity.getObfuscatd_ids().getBedienstete());
+            Utils.setSetting(this, Const.TUMO_PIDENT_NR, identity.getObfuscated_ids()
+                                                                 .getStudierende()); // Switch to identity.getObfuscated_id() in the future
+            Utils.setSetting(this, Const.TUMO_STUDENT_ID, identity.getObfuscated_ids()
+                                                                  .getStudierende());
+            Utils.setSetting(this, Const.TUMO_EXTERNAL_ID, identity.getObfuscated_ids()
+                                                                   .getExtern());
+            Utils.setSetting(this, Const.TUMO_EMPLOYEE_ID, identity.getObfuscated_ids()
+                                                                   .getBedienstete());
 
             return null;
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/Identity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/Identity.kt
@@ -4,10 +4,10 @@ import org.simpleframework.xml.Element
 import org.simpleframework.xml.Root
 
 @Root(name = "row")
-data class Identity(@field:Element var vorname: String,
-                    @field:Element var familienname: String,
-                    @field:Element var kennung: String,
-                    @field:Element var obfuscated_id: String,
-                    @field:Element var obfuscated_ids: ObfuscatedIds) {
+data class Identity(@field:Element var vorname: String = "",
+                    @field:Element var familienname: String = "",
+                    @field:Element var kennung: String = "",
+                    @field:Element var obfuscated_id: String = "",
+                    @field:Element var obfuscated_ids: ObfuscatedIds = ObfuscatedIds()) {
     override fun toString(): String = "$vorname $familienname"
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/Identity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/Identity.kt
@@ -7,7 +7,7 @@ import org.simpleframework.xml.Root
 data class Identity(@field:Element var vorname: String,
                     @field:Element var familienname: String,
                     @field:Element var kennung: String,
-                    @field:Element var obfuscatd_id: String,
-                    @field:Element var obfuscatd_ids: ObfuscatedIds) {
+                    @field:Element var obfuscated_id: String,
+                    @field:Element var obfuscated_ids: ObfuscatedIds) {
     override fun toString(): String = "$vorname $familienname"
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/ObfuscatedIds.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/ObfuscatedIds.kt
@@ -6,6 +6,4 @@ import org.simpleframework.xml.Root
 @Root(name = "row")
 data class ObfuscatedIds(@field:Element var studierende: String = "",
                          @field:Element var bedienstete: String = "",
-                         @field:Element var extern: String = "") {
-
-}
+                         @field:Element var extern: String = "")


### PR DESCRIPTION
Fixes #554 

Git blames @kordianbruck in commit 2bfd63eeb1f401b8ff339a1ee70477946f490fd1 for removing the default values for the Identity, thus removing the default constructor of the model and crashing simplexml. 🎉 

