### PR TITLE
Fix ValueRequiredException in startup wizard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation 'org.assertj:assertj-core:1.7.0'
     testImplementation 'org.robolectric:robolectric:3.5.1'
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/ObfuscatedIds.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/ObfuscatedIds.kt
@@ -4,6 +4,6 @@ import org.simpleframework.xml.Element
 import org.simpleframework.xml.Root
 
 @Root(name = "row")
-data class ObfuscatedIds(@field:Element var studierende: String = "",
-                         @field:Element var bedienstete: String = "",
-                         @field:Element var extern: String = "")
+data class ObfuscatedIds(@field:Element(required = false) var studierende: String = "",
+                         @field:Element(required = false) var bedienstete: String = "",
+                         @field:Element(required = false) var extern: String = "")

--- a/app/src/test/java/de/tum/in/tumcampusapp/models/tumo/IdentityTest.kt
+++ b/app/src/test/java/de/tum/in/tumcampusapp/models/tumo/IdentityTest.kt
@@ -1,0 +1,43 @@
+package de.tum.`in`.tumcampusapp.models.tumo
+
+import de.tum.`in`.tumcampusapp.tumonline.TUMOnlineConst
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.simpleframework.xml.core.Persister
+
+@RunWith(RobolectricTestRunner::class)
+class IdentityTest {
+
+    @Test
+    fun testParsingXML() {
+        val res = Persister().read(TUMOnlineConst.IDENTITY.response, XML_RESPONSE)
+        assert(res.ids.size == 1)
+        val identity = res.ids[0]
+        assert(identity.familienname == FAMILIENNAME_EXPECTED)
+        assert(identity.vorname == VORNAME_EXPECTED)
+        assert(identity.kennung == KENNUNG_EXPECTED)
+        assert(identity.obfuscated_id == OBFUSCATED_ID_EXPECTED)
+    }
+
+    companion object {
+        private const val KENNUNG_EXPECTED = "anId"
+        private const val VORNAME_EXPECTED = "Max"
+        private const val FAMILIENNAME_EXPECTED = "Mustermann"
+        private const val OBFUSCATED_ID_EXPECTED = "anobfuscatedID"
+        private const val XML_RESPONSE = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "                                                                   <rowset>\n" +
+                "                                                                   <row>\n" +
+                "                                                                   <kennung>$KENNUNG_EXPECTED</kennung>\n" +
+                "                                                                   <vorname>$VORNAME_EXPECTED</vorname>\n" +
+                "                                                                   <familienname>$FAMILIENNAME_EXPECTED</familienname>\n" +
+                "                                                                   <obfuscated_id>$OBFUSCATED_ID_EXPECTED</obfuscated_id>\n" +
+                "                                                                   <obfuscated_ids>\n" +
+                "                                                                   <studierende>asad</studierende>\n" +
+                "                                                                   <bedienstete isnull=\"true\"></bedienstete>\n" +
+                "                                                                   <extern isnull=\"true\"></extern>\n" +
+                "                                                                   </obfuscated_ids>\n" +
+                "                                                                   </row>\n" +
+                "                                                                   </rowset>"
+    }
+}


### PR DESCRIPTION
Set all obfuscated id fields to not being required to prevent
a VRE in startup wizard when fields bedienstete and extern aren't
set in the response.

Fixes #576


