### PR TITLE
Redirect single person search result to activity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/PersonsSearchActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/PersonsSearchActivity.java
@@ -122,6 +122,15 @@ public class PersonsSearchActivity extends ActivityForSearchingTumOnline<PersonL
         requestFetch();
     }
 
+    private void proceedToPersonDetails(PersonList response )    {
+        lvPersons.setAdapter(null);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable("personObject", response.getPersons().get(0));
+        Intent intent = new Intent(this, PersonsDetailsActivity.class);
+        intent.putExtras(bundle);
+        startActivity(intent);
+    }
+
     /**
      * Handles the XML response from TUMOnline by de-serializing the information
      * to model entities.
@@ -130,8 +139,10 @@ public class PersonsSearchActivity extends ActivityForSearchingTumOnline<PersonL
      */
     @Override
     public void onLoadFinished(PersonList response) {
-        if (response.getPersons() == null) {
+        if (response.getPersons() == null || response.getPersons().isEmpty()) {
             lvPersons.setAdapter(new NoResultsAdapter(this));
+        } else if (response.getPersons().size() == 1){
+            proceedToPersonDetails(response);
         } else {
             ListAdapter adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, android.R.id.text1, response.getPersons());
             lvPersons.setAdapter(adapter);


### PR DESCRIPTION
## Issue

This fixes the following issue(s): 558 -Single results in PersonSearch should proceed to PersonDetails
Now if there's only one search result it will directly proceed to PersonDetails

## Screenshot

## Why this is useful for all students
Because its more comy
