### PR TITLE
Fix SecurityException when scanning for wifis

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/services/ScanResultsAvailableReceiver.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/services/ScanResultsAvailableReceiver.java
@@ -15,7 +15,6 @@ import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
-import android.util.Log;
 
 import java.util.Calendar;
 import java.util.List;

--- a/app/src/main/java/de/tum/in/tumcampusapp/services/ScanResultsAvailableReceiver.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/services/ScanResultsAvailableReceiver.java
@@ -15,6 +15,7 @@ import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
+import android.util.Log;
 
 import java.util.Calendar;
 import java.util.List;
@@ -69,6 +70,12 @@ public class ScanResultsAvailableReceiver extends BroadcastReceiver {
         boolean locationsEnabled = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
         boolean wifiScansEnabled = Utils.getInternalSettingBool(context, WifiMeasurementManager.WIFI_SCANS_ALLOWED, false);
         boolean nextScanScheduled = false;
+
+        if (!locationsEnabled) {
+            //Stop here as wifi.getScanResults will either return an empty list or throw an exception (on android 6.0.0)
+            return;
+        }
+
         WifiScanHandler wifiScanHandler = WifiScanHandler.getInstance(context);
         List<ScanResult> scan = wifi.getScanResults();
         for (final ScanResult network : scan) {
@@ -82,7 +89,7 @@ public class ScanResultsAvailableReceiver extends BroadcastReceiver {
             }
 
             //if user allowed us to store his signal strength, store measurement to the local DB and later sync to remote
-            if (locationsEnabled && wifiScansEnabled) {
+            if (wifiScansEnabled) {
                 storeWifiMeasurement(context, network);
                 nextScanScheduled = true;
             }


### PR DESCRIPTION
On specific android versions wifiManager.getScanResults didn't
return an empty list but instead threw an exception. Check if
permission has been granted and only if so access scan results.

Fixes #569

