### PR TITLE
Fix sync

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dataAccessObjects/SyncDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dataAccessObjects/SyncDao.java
@@ -12,7 +12,7 @@ import de.tum.in.tumcampusapp.models.dbEntities.Sync;
 @Dao
 public interface SyncDao {
     @Nullable
-    @Query("SELECT lastSync FROM sync WHERE (strftime('%s','now') - strftime('%s',lastSync)) > :seconds AND id=:id")
+    @Query("SELECT lastSync FROM sync WHERE (strftime('%s','now') - strftime('%s',lastSync)) < :seconds AND id=:id")
     String getSyncSince(String id, int seconds);
 
     @Query("DELETE FROM sync")

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/SyncManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/SyncManager.java
@@ -46,7 +46,7 @@ public class SyncManager {
      * @return true if sync is needed, else false
      */
     public boolean needSync(String id, int seconds) {
-        return dao.getSyncSince(id, seconds) != null;
+        return dao.getSyncSince(id, seconds) == null;
     }
 
     /**

--- a/app/src/test/java/de/tum/in/tumcampusapp/managers/SyncManagerTest.java
+++ b/app/src/test/java/de/tum/in/tumcampusapp/managers/SyncManagerTest.java
@@ -1,0 +1,92 @@
+package de.tum.in.tumcampusapp.managers;
+
+import android.support.v4.view.ViewPager;
+import android.view.View;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.Date;
+
+import de.tum.in.tumcampusapp.BuildConfig;
+import de.tum.in.tumcampusapp.auxiliary.Utils;
+import de.tum.in.tumcampusapp.database.TcaDb;
+import de.tum.in.tumcampusapp.database.dataAccessObjects.SyncDao;
+import de.tum.in.tumcampusapp.models.dbEntities.Sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class SyncManagerTest {
+    private SyncManager syncManager;
+    private SyncDao dao;
+
+    @Before
+    public void setUp() {
+        dao = TcaDb.getInstance(RuntimeEnvironment.application).syncDao();
+        dao.removeCache();
+        syncManager = new SyncManager(RuntimeEnvironment.application);
+    }
+
+    @After
+    public void tearDown() {
+        TcaDb.getInstance(RuntimeEnvironment.application).close();
+    }
+
+    /**
+     * Default needSync usage - specific sync target hasn't been synced for a while
+     * Expected output: returns true
+     */
+    @Test
+    public void needSyncNeedsResyncTest() {
+        String sync_id = "needSyncNeedsResyncTest";
+        dao.insert(new Sync(sync_id, "0"));
+        assertThat(syncManager.needSync(sync_id, 1234)).isTrue();
+    }
+
+    /**
+     * Sync table is missing specified ID
+     * Expected output: returns true
+     */
+    @Test
+    public void needSyncNoIdTest() {
+        String sync_id = "needSyncNoIdTest";
+        assertThat(syncManager.needSync(sync_id, 1234)).isTrue();
+    }
+
+    /**
+     * Last sync happened earlier than required
+     * Expected output: returns false
+     */
+    @Test
+    public void needSyncTooEarlyTest() {
+        String sync_id = "needSyncTooEarlyTest";
+        String now = Utils.getDateTimeString(new Date());
+        dao.insert(new Sync(sync_id, now));
+        assertThat(syncManager.needSync(sync_id, 1234)).isFalse();
+    }
+
+    /**
+     * Non direct way of checking that Sync entity has been replaced through needSync
+     * Workflow:
+     * 1. add sync with specific id and "old" timestamp
+     * 2. verify needSync returns true
+     * 3. use target function to update same id
+     * 4. verify needSync returns false
+     */
+    @Test
+    public void replaceIntoDbNormal() {
+        String sync_id = "replaceIntoDbNormal";
+        dao.insert(new Sync(sync_id, "0"));
+        assertThat(syncManager.needSync(sync_id, 1234)).isTrue();
+        syncManager.replaceIntoDb(sync_id);
+        assertThat(syncManager.needSync(sync_id, 1234)).isFalse();
+    }
+}

--- a/app/src/test/java/de/tum/in/tumcampusapp/managers/SyncManagerTest.java
+++ b/app/src/test/java/de/tum/in/tumcampusapp/managers/SyncManagerTest.java
@@ -1,13 +1,9 @@
 package de.tum.in.tumcampusapp.managers;
 
-import android.support.v4.view.ViewPager;
-import android.view.View;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;


### PR DESCRIPTION
## Issue

SyncManager's `sync` table is not populated with *sync* information from managers. On empty table, needSync always returns `false`, because **id** is not matched.

The following managers are using `SyncManager`:

- [CafeteriaManager](https://github.com/TCA-Team/TumCampusApp/blob/master/app/src/main/java/de/tum/in/tumcampusapp/managers/CafeteriaManager.java#L79)
- [CafeteriaMenuManager](https://github.com/TCA-Team/TumCampusApp/blob/master/app/src/main/java/de/tum/in/tumcampusapp/managers/CafeteriaMenuManager.java#L88)
- [KinoManager](https://github.com/TCA-Team/TumCampusApp/blob/master/app/src/main/java/de/tum/in/tumcampusapp/managers/KinoManager.java#L50)
- [NewsManager](https://github.com/TCA-Team/TumCampusApp/blob/master/app/src/main/java/de/tum/in/tumcampusapp/managers/NewsManager.java#L85)
- [StudyRoomGroupManager](https://github.com/TCA-Team/TumCampusApp/blob/master/app/src/main/java/de/tum/in/tumcampusapp/managers/StudyRoomGroupManager.java#L52) - **not sure what for is it using it, as it just pushes to Dao regardless and doesn't seem to use `needSync`**

## Screenshot

Not applicable

## Why this is useful for all students

Being up to date is nice