### PR TITLE
Handle no last id Kino (empty table) case

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/KinoManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/KinoManager.java
@@ -56,7 +56,8 @@ public class KinoManager {
         NetUtils net = new NetUtils(mContext);
 
         // download from kino database
-        Optional<JSONArray> jsonArray = net.downloadJsonArray(KINO_URL + dao.getLastId(), CacheManager.VALIDITY_ONE_DAY, force);
+        String lastId = dao.getLastId();
+        Optional<JSONArray> jsonArray = net.downloadJsonArray(KINO_URL + (lastId == null? "": lastId), CacheManager.VALIDITY_ONE_DAY, force);
 
         if (!jsonArray.isPresent()) {
             return;


### PR DESCRIPTION
## Issue
When the Kino table is empty, issuing getLastId returns null, which gets concatenated into `KINO_URL` and when querying API with `null` at the end (Java converts it into `null` for concatenation), which responds with `bad action`.

## Screenshot
Not applicable

## Why this is useful for all students

Getting fresh into TUMCampusApp and seeing future movies is nice than only seeing one from news card.