### PR TITLE
Fix DB Date format conversion

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/database/Converters.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/Converters.java
@@ -14,6 +14,6 @@ public class Converters {
 
     @TypeConverter
     public static String fromDate(Date date) {
-        return Utils.getDateString(date);
+        return Utils.getDateTimeString(date);
     }
 }


### PR DESCRIPTION
## Issue

#607 introduced fixes to timezone problem, which changed database's string-to-date conversion function, but date-to-string remained using different format. When running the application, it complains with non-crashing exceptions that the given string format is not recognized.

This PR uses the format that was introduced in #607 for date-to-string conversion.

## Screenshot

Not applicable

## Why this is useful for all students

Not applicable