### PR TITLE
Allow sorting of cards

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/MainActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/MainActivity.java
@@ -263,13 +263,17 @@ public class MainActivity extends BaseActivity implements SwipeRefreshLayout.OnR
                   .smoothScrollToPosition(mCardsView, null, 0);
     }
 
+    public interface ItemTouchHelperAdapter {
+        void onItemMove(int fromPosition, int toPosition);
+    }
+
     /**
      * A touch helper class, Handles swipe to dismiss events
      */
     private class MainActivityTouchHelperCallback extends ItemTouchHelper.SimpleCallback {
 
         public MainActivityTouchHelperCallback() {
-            super(0, ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT);
+            super(ItemTouchHelper.UP | ItemTouchHelper.DOWN, ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT);
         }
 
         @Override
@@ -284,13 +288,13 @@ public class MainActivity extends BaseActivity implements SwipeRefreshLayout.OnR
 
         @Override
         public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
-            //Moving is not allowed as per flags
-            return false;
+            mAdapter.onItemMove(viewHolder.getAdapterPosition(), target.getAdapterPosition());
+            return true;
         }
 
         @Override
         public boolean isLongPressDragEnabled() {
-            return false;
+            return true;
         }
 
         @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/adapters/CardsAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/adapters/CardsAdapter.java
@@ -3,6 +3,7 @@ package de.tum.in.tumcampusapp.adapters;
 import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
 
+import de.tum.in.tumcampusapp.activities.MainActivity;
 import de.tum.in.tumcampusapp.cards.CafeteriaMenuCard;
 import de.tum.in.tumcampusapp.cards.ChatMessagesCard;
 import de.tum.in.tumcampusapp.cards.EduroamCard;
@@ -21,7 +22,7 @@ import de.tum.in.tumcampusapp.managers.CardManager;
 /**
  * Adapter for the cards start page used in {@link de.tum.in.tumcampusapp.activities.MainActivity}
  */
-public class CardsAdapter extends RecyclerView.Adapter<Card.CardViewHolder> {
+public class CardsAdapter extends RecyclerView.Adapter<Card.CardViewHolder> implements MainActivity.ItemTouchHelperAdapter{
 
     public static Card getItem(int i) {
         return CardManager.getCard(i);
@@ -99,5 +100,16 @@ public class CardsAdapter extends RecyclerView.Adapter<Card.CardViewHolder> {
     public void insert(int position, Card item) {
         CardManager.insert(position, item);
         notifyItemInserted(position);
+    }
+
+    @Override
+    public void onItemMove(int fromPosition, int toPosition) {
+        Card card = CardManager.remove(fromPosition);
+        CardManager.insert(toPosition,card);
+
+        for(int index = 0; index < CardManager.getCardCount();index++){
+            CardManager.getCard(index).setPosition(index);
+        }
+        notifyItemMoved(fromPosition, toPosition);
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/adapters/CardsAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/adapters/CardsAdapter.java
@@ -104,12 +104,33 @@ public class CardsAdapter extends RecyclerView.Adapter<Card.CardViewHolder> impl
 
     @Override
     public void onItemMove(int fromPosition, int toPosition) {
+        toPosition = validatePosition(fromPosition,toPosition);
         Card card = CardManager.remove(fromPosition);
         CardManager.insert(toPosition,card);
-
+        //Update card positions so they stay the same even when the app is closed
         for(int index = 0; index < CardManager.getCardCount();index++){
             CardManager.getCard(index).setPosition(index);
         }
         notifyItemMoved(fromPosition, toPosition);
+    }
+
+    private int validatePosition(int fromPosition, int toPosition){
+        Card selectedCard = CardManager.getCard(fromPosition);
+        Card cardAtPosition = CardManager.getCard(toPosition);
+        // If there is a support card, it should always be the first one
+        // except when it's been dismissed.
+        // Restore card should stay at the bottom
+        if(selectedCard instanceof RestoreCard) {
+            return fromPosition;
+        } else if(selectedCard instanceof Support) {
+            return fromPosition;
+        }
+        if(cardAtPosition instanceof Support) {
+            return toPosition + 1;
+        } else if(cardAtPosition instanceof RestoreCard) {
+            return toPosition - 1;
+        } else {
+            return toPosition;
+        }
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Const.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Const.kt
@@ -145,4 +145,6 @@ object Const {
   
     const val DATE_AND_TIME = "yyyy-MM-dd HH:mm:ss"
     const val DATE_ONLY = "yyyy-MM-dd"
+
+    const val CARD_POSITION_PREFERENCE_SUFFIX = "_card_position"
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/generic/Card.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/generic/Card.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.content.ContextCompat;
@@ -31,7 +32,7 @@ import de.tum.in.tumcampusapp.managers.CardManager;
 /**
  * Base class for all cards
  */
-public abstract class Card {
+public abstract class Card implements Comparable<Card> {
     public static final String DISCARD_SETTINGS_START = "discard_settings_start";
     public static final String DISCARD_SETTINGS_PHONE = "discard_settings_phone";
 
@@ -208,6 +209,28 @@ public abstract class Card {
      * @return a unique identifier among the type of the card
      */
     public abstract int getId();
+
+
+    public int getPosition(){
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        return prefs.getInt(this.getClass().getSimpleName()+"_position",-1);
+    }
+
+    public void setPosition(int position){
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        Editor e = prefs.edit();
+        e.putInt(this.getClass().getSimpleName() + "_position", position);
+        e.apply();
+    }
+
+    @Override
+    public int compareTo(@NonNull Card card) {
+        if(card.getPosition()>getPosition()) {
+            return -1;
+        } else {
+            return 1;
+        }
+    }
 
     @Nullable
     public RemoteViews getRemoteViews(Context context) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/cards/generic/Card.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/cards/generic/Card.java
@@ -29,6 +29,8 @@ import de.tum.in.tumcampusapp.auxiliary.Const;
 import de.tum.in.tumcampusapp.auxiliary.ImplicitCounter;
 import de.tum.in.tumcampusapp.managers.CardManager;
 
+import static de.tum.in.tumcampusapp.auxiliary.Const.CARD_POSITION_PREFERENCE_SUFFIX;
+
 /**
  * Base class for all cards
  */
@@ -210,26 +212,23 @@ public abstract class Card implements Comparable<Card> {
      */
     public abstract int getId();
 
-
-    public int getPosition(){
+    public int getPosition() {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
-        return prefs.getInt(this.getClass().getSimpleName()+"_position",-1);
+        return prefs.getInt(String.format("%s%s", this.getClass()
+                                                      .getSimpleName(), CARD_POSITION_PREFERENCE_SUFFIX), -1);
     }
 
-    public void setPosition(int position){
+    public void setPosition(int position) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
         Editor e = prefs.edit();
-        e.putInt(this.getClass().getSimpleName() + "_position", position);
+        e.putInt(String.format("%s%s", this.getClass()
+                                           .getSimpleName(), CARD_POSITION_PREFERENCE_SUFFIX), position);
         e.apply();
     }
 
     @Override
     public int compareTo(@NonNull Card card) {
-        if(card.getPosition()>getPosition()) {
-            return -1;
-        } else {
-            return 1;
-        }
+        return Integer.compare(getPosition(),card.getPosition());
     }
 
     @Nullable

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/CardManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/CardManager.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import de.tum.in.tumcampusapp.auxiliary.AccessTokenManager;
@@ -48,7 +49,13 @@ public final class CardManager {
      * @param card Card that should be added
      */
     public static void addCard(Card card) {
+        if (card.getPosition() == -1) {
+            card.setPosition(newCards.size());
+        }
+
         newCards.add(card);
+
+        Collections.sort(newCards);
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/CardManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/CardManager.java
@@ -2,6 +2,8 @@ package de.tum.in.tumcampusapp.managers;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import android.preference.PreferenceManager;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,6 +17,8 @@ import de.tum.in.tumcampusapp.cards.NoInternetCard;
 import de.tum.in.tumcampusapp.cards.RestoreCard;
 import de.tum.in.tumcampusapp.cards.Support;
 import de.tum.in.tumcampusapp.cards.generic.Card;
+
+import static de.tum.in.tumcampusapp.auxiliary.Const.CARD_POSITION_PREFERENCE_SUFFIX;
 
 /**
  * Card manager, manages inserting, dismissing, updating and displaying of cards
@@ -79,6 +83,16 @@ public final class CardManager {
      */
     public static Card getCard(int pos) {
         return cards.get(pos);
+    }
+
+    public static void restorePositions(Context context){
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        Editor editor = preferences.edit();
+        for(String s : preferences.getAll().keySet()){
+            if(s.endsWith(CARD_POSITION_PREFERENCE_SUFFIX))
+                editor.remove(s);
+        }
+        editor.apply();
     }
 
     /**
@@ -176,6 +190,7 @@ public final class CardManager {
              .apply();
         AbstractManager.getDb(context)
                        .execSQL("UPDATE news SET dismissed=0");
+        restorePositions(context);
     }
 
     public static List<Card> getCards() {


### PR DESCRIPTION
Cards that are of a different type can be drag and dropped
up and down the list to change their location (persistent).

## Issue

This fixes the following issue(s): #228

## Screenshot

![screenshot_20180118-004710](https://user-images.githubusercontent.com/7032584/35073472-3a5bace4-fbe9-11e7-8640-4365179f742d.png)


## Why this is useful for all students

Users can change positions of cards according to their needs

