### PR TITLE
Add details bottom sheet to calendar

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/CalendarActivity.java
@@ -424,6 +424,6 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<CalendarRowS
         CalendarItem item = calendarManager.getCalendarItemByStartAndEndTime(weekViewEvent.getStartTime(), weekViewEvent.getEndTime());
         bundle.putString(CALENDAR_ID_PARAM, item.getNr());
         detailsFragment.setArguments(bundle);
-        detailsFragment.show(getSupportFragmentManager(), "CalendarDialog");
+        detailsFragment.show(getSupportFragmentManager(), null);
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/activities/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/activities/CalendarActivity.java
@@ -38,11 +38,14 @@ import de.tum.in.tumcampusapp.activities.generic.ActivityForAccessingTumOnline;
 import de.tum.in.tumcampusapp.auxiliary.Const;
 import de.tum.in.tumcampusapp.auxiliary.Utils;
 import de.tum.in.tumcampusapp.auxiliary.calendar.IntegratedCalendarEvent;
+import de.tum.in.tumcampusapp.fragments.CalendarDetailsFragment;
 import de.tum.in.tumcampusapp.managers.CalendarManager;
 import de.tum.in.tumcampusapp.managers.SyncManager;
 import de.tum.in.tumcampusapp.models.tumo.CalendarItem;
 import de.tum.in.tumcampusapp.models.tumo.CalendarRowSet;
 import de.tum.in.tumcampusapp.tumonline.TUMOnlineConst;
+
+import static de.tum.in.tumcampusapp.auxiliary.Const.CALENDAR_ID_PARAM;
 
 /**
  * Activity showing the user's calendar. Calendar items (events) are fetched from TUMOnline and displayed as blocks on a timeline.
@@ -416,9 +419,11 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<CalendarRowS
 
     @Override
     public void onEventClick(WeekViewEvent weekViewEvent, RectF rectF) {
-        IntegratedCalendarEvent event = (IntegratedCalendarEvent) weekViewEvent;
-        Intent i = new Intent(this, RoomFinderDetailsActivity.class);
-        i.putExtra(RoomFinderDetailsActivity.EXTRA_LOCATION, event.getLocation());
-        this.startActivity(i);
+        CalendarDetailsFragment detailsFragment = new CalendarDetailsFragment();
+        Bundle bundle = new Bundle();
+        CalendarItem item = calendarManager.getCalendarItemByStartAndEndTime(weekViewEvent.getStartTime(), weekViewEvent.getEndTime());
+        bundle.putString(CALENDAR_ID_PARAM, item.getNr());
+        detailsFragment.setArguments(bundle);
+        detailsFragment.show(getSupportFragmentManager(), "CalendarDialog");
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Const.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Const.kt
@@ -145,4 +145,6 @@ object Const {
   
     const val DATE_AND_TIME = "yyyy-MM-dd HH:mm:ss"
     const val DATE_ONLY = "yyyy-MM-dd"
+
+    const val CALENDAR_ID_PARAM = "calendar_id"
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Utils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Utils.java
@@ -23,11 +23,6 @@ import com.google.common.escape.Escaper;
 import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
 
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.DateTimeFormatterBuilder;
-import org.joda.time.format.DateTimeParser;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +35,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import de.tum.in.tumcampusapp.BuildConfig;
 
@@ -146,6 +143,12 @@ public final class Utils {
             log(e, str);
         }
         return date;
+    }
+
+    public static String getEventDateString(Date begin, Date end) {
+        SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss", Locale.US);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        return String.format("%s %s - %s", dateFormat.format(begin), timeFormat.format(begin), timeFormat.format(end));
     }
 
     /**
@@ -642,4 +645,16 @@ public final class Utils {
         }
         return ((float) level / (float) scale) * 100.0f;
     }
+
+    public static String extractRoomNumberFromLocation(String location){
+        Pattern pattern = Pattern.compile("\\((.*?)\\)");
+        Matcher matcher = pattern.matcher(location);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        else {
+            return location;
+        }
+    }
+
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Utils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/auxiliary/Utils.java
@@ -145,12 +145,6 @@ public final class Utils {
         return date;
     }
 
-    public static String getEventDateString(Date begin, Date end) {
-        SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss", Locale.US);
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
-        return String.format("%s %s - %s", dateFormat.format(begin), timeFormat.format(begin), timeFormat.format(end));
-    }
-
     /**
      * Get a value from the default shared preferences
      *

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/CalendarDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/CalendarDao.java
@@ -59,4 +59,10 @@ public interface CalendarDao {
            "ORDER BY dtstart LIMIT 1) ON status!='CANCEL' AND datetime('now', 'localtime')<dtend AND dtstart<=maxstart " +
            "ORDER BY dtend, dtstart LIMIT 4")
     List<CalendarItem> getNextCalendarItems();
+
+    @Query("SELECT * FROM calendar WHERE dtstart LIKE '%' || :start AND dtend LIKE '%' || :end ")
+    CalendarItem getCalendarItemByStartAndEndTime(String start, String end);
+
+    @Query("SELECT * FROM calendar WHERE nr=:id")
+    CalendarItem getCalendarItemById(String id);
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/fragments/CalendarDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/fragments/CalendarDetailsFragment.kt
@@ -42,7 +42,7 @@ class CalendarDetailsFragment : BottomSheetDialogFragment() {
         val descriptionTextView = view.findViewById<TextView>(R.id.bottomSheetDescriptionText)
 
         titleTextView.text = calendarItem.title
-        dateTextView.text = Utils.getEventDateString(Utils.getDateTime(calendarItem.dtstart), Utils.getDateTime(calendarItem.dtend))
+        dateTextView.text = calendarItem.getEventDateString()
         locationTextView.text = calendarItem.location
         descriptionTextView.text = calendarItem.description
         locationTextView.setOnClickListener { onLocationClicked(calendarItem.location) }

--- a/app/src/main/java/de/tum/in/tumcampusapp/fragments/CalendarDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/fragments/CalendarDetailsFragment.kt
@@ -1,0 +1,57 @@
+package de.tum.`in`.tumcampusapp.fragments
+
+import android.app.SearchManager
+import android.content.Intent
+import android.os.Bundle
+import android.support.design.widget.BottomSheetDialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import de.tum.`in`.tumcampusapp.R
+import de.tum.`in`.tumcampusapp.activities.RoomFinderActivity
+import de.tum.`in`.tumcampusapp.auxiliary.Const.CALENDAR_ID_PARAM
+import de.tum.`in`.tumcampusapp.auxiliary.Utils
+import de.tum.`in`.tumcampusapp.database.TcaDb
+import de.tum.`in`.tumcampusapp.database.dao.CalendarDao
+import de.tum.`in`.tumcampusapp.models.tumo.CalendarItem
+
+class CalendarDetailsFragment : BottomSheetDialogFragment() {
+
+    private lateinit var dao: CalendarDao
+
+    private lateinit var calendarId: String
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val v = inflater.inflate(R.layout.fragment_calendar_details, container, false)
+        calendarId = arguments?.getString(CALENDAR_ID_PARAM)!!
+        dao = TcaDb.getInstance(context).calendarDao()
+        return v
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val calendarItem = dao.getCalendarItemById(calendarId)
+        updateView(calendarItem, view)
+    }
+
+
+    private fun updateView(calendarItem: CalendarItem, view: View) {
+        val titleTextView = view.findViewById<TextView>(R.id.bottomSheetHeading)
+        val dateTextView = view.findViewById<TextView>(R.id.bottomSheetDateText)
+        val locationTextView = view.findViewById<TextView>(R.id.bottomSheetLocationText)
+        val descriptionTextView = view.findViewById<TextView>(R.id.bottomSheetDescriptionText)
+
+        titleTextView.text = calendarItem.title
+        dateTextView.text = Utils.getEventDateString(Utils.getDateTime(calendarItem.dtstart), Utils.getDateTime(calendarItem.dtend))
+        locationTextView.text = calendarItem.location
+        descriptionTextView.text = calendarItem.description
+        locationTextView.setOnClickListener { onLocationClicked(calendarItem.location) }
+    }
+
+    private fun onLocationClicked(location: String) {
+        val findStudyRoomIntent = Intent()
+        findStudyRoomIntent.putExtra(SearchManager.QUERY, Utils.extractRoomNumberFromLocation(location))
+        findStudyRoomIntent.setClass(context, RoomFinderActivity::class.java)
+        startActivity(findStudyRoomIntent)
+    }
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/CalendarManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/CalendarManager.java
@@ -184,6 +184,10 @@ public class CalendarManager extends AbstractManager implements Card.ProvidesCar
         return lectures;
     }
 
+    public CalendarItem getCalendarItemByStartAndEndTime(Calendar start, Calendar end) {
+        return calendarDao.getCalendarItemByStartAndEndTime(Utils.getDateTimeString(start.getTime()), Utils.getDateTimeString(end.getTime()));
+    }
+
     public void importCalendar(CalendarRowSet myCalendarList) {
 
         // Cleanup cache before importing

--- a/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/CalendarItem.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/models/tumo/CalendarItem.kt
@@ -7,6 +7,7 @@ import android.content.ContentValues
 import android.provider.CalendarContract
 import de.tum.`in`.tumcampusapp.auxiliary.Utils
 import de.tum.`in`.tumcampusapp.auxiliary.calendar.IntegratedCalendarEvent
+import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
 
@@ -79,6 +80,16 @@ data class CalendarItem(@PrimaryKey
                 .replaceAll("")!!
                 .trim { it <= ' ' }
     }
+
+
+    fun getEventDateString(): String {
+        val timeFormat = SimpleDateFormat("HH:mm", Locale.US)
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        val startDate = Utils.getDateTime(dtstart)
+        val endDate = Utils.getDateTime(dtend)
+        return String.format("%s %s - %s", dateFormat.format(startDate), timeFormat.format(startDate), timeFormat.format(endDate))
+    }
+
 
     /**
      * Prepares ContentValues object with related values plugged

--- a/app/src/main/res/layout/fragment_calendar_details.xml
+++ b/app/src/main/res/layout/fragment_calendar_details.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/bottomSheet"
+    android:layout_width="match_parent"
+    android:layout_height="300dp"
+    >
+
+    <LinearLayout
+        android:id="@+id/bottomSheetLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_behavior="@string/bottom_sheet_behavior">
+
+        <LinearLayout
+            android:id="@+id/bottomSheetHeadingLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="5dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <android.support.design.widget.FloatingActionButton
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/activity_vertical_margin"
+                    android:src="@drawable/ic_calendar"
+                    app:backgroundTint="@color/color_primary"/>
+
+                <TextView
+                    android:id="@+id/bottomSheetHeading"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start|center_vertical"
+                    android:textAppearance="@android:style/TextAppearance.Large"
+                    />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="28dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/ic_location"/>
+
+                <TextView
+                    android:id="@+id/bottomSheetLocationText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start|center_vertical"
+                    android:layout_marginLeft="20dp"
+                    android:layout_marginStart="20dp"
+                    android:textAppearance="@android:style/TextAppearance.Medium"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+
+                android:orientation="horizontal"
+                android:paddingTop="22dp">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/ic_time"/>
+
+                <TextView
+                    android:id="@+id/bottomSheetDateText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start|center_vertical"
+                    android:layout_marginLeft="20dp"
+                    android:layout_marginStart="20dp"
+                    android:textAppearance="@android:style/TextAppearance.Medium"/>
+            </LinearLayout>
+
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingTop="22dp">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/ic_info"/>
+
+                <TextView
+                    android:id="@+id/bottomSheetDescriptionText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start|center_vertical"
+                    android:layout_marginLeft="20dp"
+                    android:textAppearance="@android:style/TextAppearance.Medium"
+                    />
+            </LinearLayout>
+        </LinearLayout>
+
+    </LinearLayout>
+</android.support.v4.widget.NestedScrollView>


### PR DESCRIPTION
- Clicking on a calendar entry will open a modal bottom sheet
with details about the entry
- Clicking on the location in the bottom sheet will open the room finder

Fixes #534

## Issue

This fixes the following issue(s): #534

## Screenshot

![screenshot_20180120-124828](https://user-images.githubusercontent.com/7032584/35183104-c3f18ade-fde0-11e7-8cf0-27e953f9a85c.png)

## Why this is useful for all students

Because users love to click on stuff 🤭
