### PR TITLE
Fix clearing cache makes app unusable

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/BuildingToGpsDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/BuildingToGpsDao.java
@@ -15,4 +15,7 @@ public interface BuildingToGpsDao {
 
     @Query("SELECT * FROM buildingtogps")
     List<BuildingToGps> getAll();
+
+    @Query("DELETE FROM buildingtogps")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/ChatMessageDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/ChatMessageDao.java
@@ -4,7 +4,6 @@ import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
-import android.database.Cursor;
 
 import java.util.List;
 
@@ -89,4 +88,7 @@ public interface ChatMessageDao {
 
     @Query(SQL_ALL_UNSENT_CURRENT_ROOM)
     Flowable<List<ChatMessage>> getAllUnsentFromCurrentRoomFlow();
+
+    @Query("DELETE FROM chat_message")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/ChatRoomDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/ChatRoomDao.java
@@ -4,10 +4,10 @@ import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
+
 import java.util.List;
 
 import de.tum.in.tumcampusapp.models.chatRoom.ChatRoomDbRow;
-import de.tum.in.tumcampusapp.models.tumcabe.ChatMessage;
 
 @Dao
 public interface ChatRoomDao {
@@ -66,4 +66,7 @@ public interface ChatRoomDao {
            "WHERE r.room=c.room " +
            "ORDER BY r.semester_id DESC, r.name")
     List<ChatRoomDbRow> getUnreadRooms();
+
+    @Query("DELETE FROM chat_room")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/FavoriteDishDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/FavoriteDishDao.java
@@ -42,4 +42,8 @@ public interface FavoriteDishDao {
            "INNER JOIN cafeteriaMenu ON cafeteriaMenu.cafeteriaId = favoriteDish.cafeteriaId " +
            "AND favoriteDish.dishName = cafeteriaMenu.name WHERE cafeteriaMenu.date = :dayMonthYear")
     List<CafeteriaMenu> getFavouritedCafeteriaMenuOnDate(String dayMonthYear);
+
+
+    @Query("DELETE FROM favoriteDish")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/LocationDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/LocationDao.java
@@ -23,4 +23,7 @@ public interface LocationDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void replaceInto(Location location);
+
+    @Query("DELETE FROM location")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/RecentsDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/RecentsDao.java
@@ -19,4 +19,7 @@ public interface RecentsDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     void insert(Recent recent);
+
+    @Query("DELETE FROM recent")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/TransportDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/TransportDao.java
@@ -5,8 +5,6 @@ import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
 
-import java.util.List;
-
 import de.tum.in.tumcampusapp.models.transport.TransportFavorites;
 import de.tum.in.tumcampusapp.models.transport.WidgetsTransport;
 
@@ -30,4 +28,7 @@ public interface TransportDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void replaceWidget(WidgetsTransport widgetsTransport);
+
+    @Query("DELETE FROM transport_favorites")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/dao/TumLockDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/dao/TumLockDao.java
@@ -27,4 +27,7 @@ public interface TumLockDao {
 
     @Insert
     void setLock(TumLock lock);
+
+    @Query("DELETE FROM tumLock")
+    void removeCache();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/managers/AbstractManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/managers/AbstractManager.java
@@ -7,6 +7,7 @@ import android.database.sqlite.SQLiteDatabase;
 import java.io.File;
 
 import de.tum.in.tumcampusapp.auxiliary.Const;
+import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.services.BackgroundService;
 import de.tum.in.tumcampusapp.services.DownloadService;
 import de.tum.in.tumcampusapp.services.SendMessageService;
@@ -64,32 +65,42 @@ public class AbstractManager {
 
         db.beginTransaction();
         try {
-            db.execSQL("DROP TABLE IF EXISTS cafeterias");
-            db.execSQL("DROP TABLE IF EXISTS cafeterias_menus");
-            db.execSQL("DROP TABLE IF EXISTS calendar");
-            db.execSQL("DROP TABLE IF EXISTS kalendar_events");
-            db.execSQL("DROP TABLE IF EXISTS locations");
-            db.execSQL("DROP TABLE IF EXISTS news");
-            db.execSQL("DROP TABLE IF EXISTS news_sources");
-            db.execSQL("DROP TABLE IF EXISTS recents");
-            db.execSQL("DROP TABLE IF EXISTS room_locations");
-            db.execSQL("DROP TABLE IF EXISTS syncs");
+
             db.execSQL("DROP TABLE IF EXISTS suggestions_lecture");
             db.execSQL("DROP TABLE IF EXISTS suggestions_mvv");
             db.execSQL("DROP TABLE IF EXISTS suggestions_persons");
             db.execSQL("DROP TABLE IF EXISTS suggestions_rooms");
-            db.execSQL("DROP TABLE IF EXISTS unsent_chat_message");
-            db.execSQL("DROP TABLE IF EXISTS chat_message");
-            db.execSQL("DROP TABLE IF EXISTS chat_room");
-            db.execSQL("DROP TABLE IF EXISTS tumLocks");
-            db.execSQL("DROP TABLE IF EXISTS openQuestions");
-            db.execSQL("DROP TABLE IF EXISTS ownQuestions");
-            db.execSQL("DROP TABLE IF EXISTS faculties");
-            db.execSQL("DROP TABLE IF EXISTS transport_favorites");
+
             CacheManager.clearCache(c);
             db.setTransactionSuccessful();
         } finally {
             db.endTransaction();
         }
+
+        TcaDb tdb = TcaDb.getInstance(c);
+        tdb.cafeteriaDao().removeCache();
+        tdb.cafeteriaMenuDao().removeCache();
+        tdb.calendarDao().flush();
+        tdb.locationDao().removeCache();
+        tdb.newsDao().flush();
+        tdb.newsSourcesDao().flush();
+        tdb.recentsDao().removeCache();
+        tdb.roomLocationsDao().flush();
+        tdb.syncDao().removeCache();
+        tdb.chatMessageDao().removeCache();
+        tdb.chatRoomDao().removeCache();
+        tdb.openQuestionsDao().flush();
+        tdb.ownQuestionsDao().flush();
+        tdb.tumLockDao().removeCache();
+        tdb.facultyDao().flush();
+        tdb.transportDao().removeCache();
+        tdb.studyRoomDao().removeCache();
+        tdb.studyRoomGroupDao().removeCache();
+        tdb.kinoDao().flush();
+        tdb.widgetsTimetableBlacklistDao().flush();
+        tdb.notificationDao().cleanup();
+        tdb.favoriteDishDao().removeCache();
+        tdb.buildingToGpsDao().removeCache();
+        tdb.wifiMeasurementDao().cleanup();
     }
 }


### PR DESCRIPTION
- Do not drop database tables but instead clear them.
Room can't handle recreation of tables yet and thus trows exceptions
when tables were deleted and not recreated.

Fixes #636


