### PR TITLE
extend thread sleep time

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/services/SendMessageService.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/services/SendMessageService.java
@@ -81,7 +81,7 @@ public class SendMessageService extends JobIntentService {
                     chatMessageViewModel.removeUnsentMessage(message.internalID);
 
                     try {
-                        Thread.sleep(1500);
+                        Thread.sleep(2000);
                     } catch (InterruptedException e) {
                         Utils.log(e);
                     }


### PR DESCRIPTION
This fixes the following issue(s):
When using the Chat with mobile data/wifi the message is not shown after sending it when the connectivity is too bad. By extending the sleep time from 1500 ms to 2000 ms it works even with a bad connection.

## Why this is useful for all students
Because the message you send should shown immediately after sending.
