### PR TITLE
Fix mensa widget empty

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.java
@@ -44,9 +44,9 @@ public class MensaWidget extends AppWidgetProvider {
             CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
             localRepository.setDb(TcaDb.getInstance(context));
             Flowable<Cafeteria> cafeteria = localRepository.getCafeteria(mensaManager.getBestMatchMensaId(context));
-            String name = cafeteria.map(cafeteria1 -> cafeteria1.getName() + " " + DateUtils.getDateTimeString(new Date()))
-                                   .blockingFirst();
-            rv.setTextViewText(R.id.mensa_widget_header, name);
+
+            cafeteria.map(cafeteria1 -> cafeteria1.getName() + " " + DateUtils.getDateTimeString(new Date()))
+                     .subscribe(mensaName -> rv.setTextViewText(R.id.mensa_widget_header, mensaName));
 
             // set the header on click to open the mensa activity
             Intent mensaIntent = new Intent(context, CafeteriaActivity.class);


### PR DESCRIPTION
- WidgetRemoteViews are not executed on the main thread
(at least it appears so) which led the observables not to emit.
- Add an additional method to Manager for creating a Cafeteria Observable
that uses the local repo and thus the default thread

Fixes #705

