### PR TITLE
Default to false for silence service

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
@@ -70,7 +70,7 @@ public class WizNavExtrasActivity extends ActivityForLoadingInBackground<Void, C
         // Only make silent service selectable if access token exists
         // Otherwise the app cannot load lectures so silence service makes no sense
         if (new AccessTokenManager(this).hasValidAccessToken()) {
-            checkSilentMode.setChecked(preferences.getBoolean(Const.SILENCE_SERVICE, true));
+            checkSilentMode.setChecked(preferences.getBoolean(Const.SILENCE_SERVICE, false));
             checkSilentMode.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 if (checkSilentMode.isChecked() &&
                     !SilenceService.hasPermissions(WizNavExtrasActivity.this)) {


### PR DESCRIPTION
We need special permissions. Those are only checked, if one tries to activate the silence service. Only logical thing to do, is to default to false, so that a student has to manually activate it.