### PR TITLE
Fix tests that use Joda datetime

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionFragment.java
@@ -16,6 +16,8 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import net.danlew.android.joda.JodaTimeAndroid;
+
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -58,6 +60,7 @@ public class CafeteriaDetailsSectionFragment extends Fragment {
         CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
         localRepository.setDb(TcaDb.getInstance(getContext()));
         cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository, mDisposable);
+        JodaTimeAndroid.init(getContext());
     }
 
     /**

--- a/app/src/test/java/de/tum/in/tumcampusapp/database/dao/CalendarDaoTest.java
+++ b/app/src/test/java/de/tum/in/tumcampusapp/database/dao/CalendarDaoTest.java
@@ -1,5 +1,7 @@
 package de.tum.in.tumcampusapp.database.dao;
 
+import net.danlew.android.joda.JodaTimeAndroid;
+
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -37,6 +39,7 @@ public class CalendarDaoTest {
         wtbDao = TcaDb.getInstance(RuntimeEnvironment.application).widgetsTimetableBlacklistDao();
         rlDao = TcaDb.getInstance(RuntimeEnvironment.application).roomLocationsDao();
         nr = 0;
+        JodaTimeAndroid.init(RuntimeEnvironment.application);
     }
 
     @After

--- a/app/src/test/java/de/tum/in/tumcampusapp/database/dao/NewsDaoTest.java
+++ b/app/src/test/java/de/tum/in/tumcampusapp/database/dao/NewsDaoTest.java
@@ -1,5 +1,7 @@
 package de.tum.in.tumcampusapp.database.dao;
 
+import net.danlew.android.joda.JodaTimeAndroid;
+
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -29,6 +31,7 @@ public class NewsDaoTest {
     public void setUp() {
         dao = TcaDb.getInstance(RuntimeEnvironment.application).newsDao();
         newsIdx = 0;
+        JodaTimeAndroid.init(RuntimeEnvironment.application);
     }
 
     @After

--- a/app/src/test/java/de/tum/in/tumcampusapp/database/dao/RoomLocationsDaoTest.java
+++ b/app/src/test/java/de/tum/in/tumcampusapp/database/dao/RoomLocationsDaoTest.java
@@ -1,5 +1,7 @@
 package de.tum.in.tumcampusapp.database.dao;
 
+import net.danlew.android.joda.JodaTimeAndroid;
+
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +33,7 @@ public class RoomLocationsDaoTest {
         dao = TcaDb.getInstance(RuntimeEnvironment.application).roomLocationsDao();
         calendarDao = TcaDb.getInstance(RuntimeEnvironment.application).calendarDao();
         nr = 0;
+        JodaTimeAndroid.init(RuntimeEnvironment.application);
     }
 
     @After


### PR DESCRIPTION
## Issue

Sometimes test that uses Joda DateTime fails (as far as I could tell, when tests are run around midnight). As well added intializations to parts of code that contain joda's datetime usage.

## Screenshot
Not applicable

## Why this is useful for all students
Having rogue test at midnight is not something anyone wants.

Fixes #640 