### PR TITLE
Duplicate code via PMD

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id 'de.aaschmid.cpd' version '1.0'
+}
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: '../findbugs.gradle'

--- a/pmd.gradle
+++ b/pmd.gradle
@@ -43,3 +43,21 @@ afterEvaluate {
         tasks.getByName('check').dependsOn(task)
     }
 }
+
+// PMD's duplicate code tool
+cpd {
+    language = 'java'
+}
+
+cpdCheck {
+    reports {
+        text.enabled = false
+        xml.enabled = true
+        xml.destination file("${buildDir}/reports/pmd/duplicates.xml")
+    }
+    source = 'src/main/java'
+    exclude "**/*.kt"
+    ignoreFailures = true
+}
+
+check.dependsOn('cpdCheck')


### PR DESCRIPTION
Couldn't find a way to reuse Gradle's built-in PMD plugin to push out duplicate analysis and only managed to get it through an additional plugin.

Resolves #586 