### PR TITLE
bugfix permission calendar

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
@@ -278,7 +278,7 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<CalendarRowS
                 new AlertDialog.Builder(this)
                         .setMessage(getString(R.string.permission_calendar_explanation))
                         .setPositiveButton(R.string.ok, (dialog, id1) -> ActivityCompat
-                                .requestPermissions(CalendarActivity.this, PERMISSIONS_CALENDAR, id1))
+                                .requestPermissions(CalendarActivity.this, PERMISSIONS_CALENDAR, id))
                         .show();
             } else {
                 ActivityCompat.requestPermissions(this, PERMISSIONS_CALENDAR, id);


### PR DESCRIPTION
## Issue
CalendarActivity.java line 281
Fatal Exception: java.lang.IllegalArgumentException
requestCode should be >= 0

occurring on Android 8