### PR TITLE
bugfix SettingsFragment

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.java
@@ -117,7 +117,9 @@ public class SettingsFragment extends PreferenceFragmentCompat implements
                     try {
                         Bitmap bmp = Picasso.get().load(url).get();
                         mContext.runOnUiThread(() -> {
-                            pref.setIcon(new BitmapDrawable(getResources(), bmp));
+                            if(isAdded()){
+                                pref.setIcon(new BitmapDrawable(getResources(), bmp));
+                            }
                         });
                     } catch (IOException e) {
                         // ignore


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
```
Fatal Exception: java.lang.IllegalStateException
Fragment SettingsFragment{19bd39d} not attached to a context.
android.support.v4.app.Fragment.requireContext (Fragment.java:611)
arrow_drop_down
android.support.v4.app.Fragment.getResources (Fragment.java:675)
arrow_right
de.tum.in.tumcampusapp.component.other.settings.SettingsFragment.lambda$null$0$SettingsFragment (SettingsFragment.java:120)
```
