### PR TITLE
don't try to load image if path is empty

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.java
@@ -109,8 +109,10 @@ public class NewsCard extends NotificationAwareCard {
         notificationBuilder.setTicker(mNews.getTitle());
         notificationBuilder.setSmallIcon(R.drawable.ic_notification);
         try {
-            Bitmap bgImg = Picasso.get().load(mNews.getImage()).get();
-            notificationBuilder.extend(new NotificationCompat.WearableExtender().setBackground(bgImg));
+            if(!mNews.getImage().isEmpty()){
+                Bitmap bgImg = Picasso.get().load(mNews.getImage()).get();
+                notificationBuilder.extend(new NotificationCompat.WearableExtender().setBackground(bgImg));
+            }
         } catch (IOException e) {
             // ignore it if download fails
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsCard.java
@@ -53,6 +53,9 @@ public class TopNewsCard extends Card {
 
     private void updateImageView(){
         String imageURL = Utils.getSetting(context, Const.NEWS_ALERT_IMAGE, "");
+        if (imageURL.isEmpty() || imageView == null) {
+            return;
+        }
         Picasso.get().load(imageURL).into(imageView, new Callback() {
             @Override
             public void onSuccess() {


### PR DESCRIPTION
## Issue

```
Fatal Exception: java.lang.IllegalArgumentException
Path must not be empty.

com.squareup.picasso.Picasso.load (Picasso.java:332)
de.tum.in.tumcampusapp.component.ui.news.NewsCard.fillNotification (NewsCard.java:112)
de.tum.in.tumcampusapp.component.ui.overview.card.NotificationAwareCard.notifyUser (NotificationAwareCard.kt:53)
de.tum.in.tumcampusapp.component.ui.overview.card.NotificationAwareCard.apply (NotificationAwareCard.kt:81)
de.tum.in.tumcampusapp.component.ui.news.NewsController.onRequestCard (NewsController.java:198)
de.tum.in.tumcampusapp.component.ui.overview.CardManager.update (CardManager.java:154)
de.tum.in.tumcampusapp.service.DownloadService.download (DownloadService.java:131)
de.tum.in.tumcampusapp.service.DownloadService.lambda$onHandleWork$0$DownloadService (DownloadService.java:187)
de.tum.in.tumcampusapp.service.DownloadService$$Lambda$0.run (Unknown Source)
```
About 400 occurrences (Crashlytics)