### PR TITLE
prevent users from sending empty or accidental feedback

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackActivity.java
@@ -343,7 +343,24 @@ public class FeedbackActivity extends BaseActivity {
                             BuildConfig.VERSION_NAME);
     }
 
-    public void sendFeedback(View view) {
+    public void onSendClicked(View view){
+        if(feedbackView.getText().toString().trim().isEmpty()){
+            if(picPaths.isEmpty()){
+                feedbackView.setError(getString(R.string.feedback_empty));
+            } else {
+                feedbackView.setError(getString(R.string.feedback_img_without_text));
+            }
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(R.string.send_feedback_question);
+        builder.setIcon(R.drawable.ic_feedback);
+        builder.setPositiveButton(R.string.send, (dialogInterface, i) -> sendFeedback());
+        builder.setNegativeButton(R.string.no, null);
+        builder.show();
+    }
+
+    public void sendFeedback() {
         sentCount = 0;
         stopListeningForLocation();
 
@@ -397,7 +414,7 @@ public class FeedbackActivity extends BaseActivity {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setMessage(R.string.feedback_sending_error);
         builder.setIcon(R.drawable.ic_error_outline);
-        builder.setPositiveButton(R.string.try_again, (dialogInterface, i) -> sendFeedback(null));
+        builder.setPositiveButton(R.string.try_again, (dialogInterface, i) -> sendFeedback());
 
         // Or save message to send later -> db table needed? / sharedPreferences
         builder.setNegativeButton(R.string.ok, null);

--- a/app/src/main/res/layout/activity_feedback.xml
+++ b/app/src/main/res/layout/activity_feedback.xml
@@ -104,7 +104,7 @@
                     style="@style/FlatButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:onClick="sendFeedback"
+                    android:onClick="onSendClicked"
                     android:text="@string/feedback_send_button"/>
             </LinearLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -537,4 +537,8 @@ Signatur: %5$s</string>
     <string name="additional_info">Zusaätzliche Infos</string>
 
     <string name="topic">Über</string>
+
+    <string name="send_feedback_question">Feedback absenden?</string>
+    <string name="feedback_empty">Bitte gib hier dein Feedback ein</string>
+    <string name="feedback_img_without_text">Bitte füge eine Beschreibung hinzu</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,4 +565,8 @@ Signature: %5$s</string>
     <string name="e_mail">E-mail</string>
     <string name="additional_info">Additional Info</string>
     <string name="Refresh">Refresh</string>
+
+    <string name="send_feedback_question">Send feedback now?</string>
+    <string name="feedback_empty">You haven\'t entered any feedback</string>
+    <string name="feedback_img_without_text">Please add a description</string>
 </resources>


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
+ Users won't be able to send empty feedback anymore
+ question asking if you really want to send the feedback now

## Screenshots
![device-2018-05-24-153720](https://user-images.githubusercontent.com/16260112/40489017-6c4a5d1c-5f68-11e8-8ae0-0b9785cbdd96.png)
![device-2018-05-24-151037](https://user-images.githubusercontent.com/16260112/40489018-6c7d10d6-5f68-11e8-8851-d1f07ce5cb0e.png)
