### PR TITLE
Implemented server calls getTickets() and getEvents() on client side

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeAPIService.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeAPIService.java
@@ -29,6 +29,8 @@ import de.tum.in.tumcampusapp.component.ui.news.model.News;
 import de.tum.in.tumcampusapp.component.ui.news.model.NewsAlert;
 import de.tum.in.tumcampusapp.component.ui.news.model.NewsSources;
 import de.tum.in.tumcampusapp.component.ui.studycard.model.StudyCard;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
 import de.tum.in.tumcampusapp.component.ui.tufilm.model.Kino;
 import io.reactivex.Observable;
 import okhttp3.MultipartBody;
@@ -54,6 +56,7 @@ import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_CHAT_MEMBERS;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_CHAT_ROOMS;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_CURRICULA;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_DEVICE;
+import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_EVENTS;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_FEEDBACK;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_KINOS;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_LOCATIONS;
@@ -64,6 +67,7 @@ import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_ROOM_FINDER_AVAIL
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_ROOM_FINDER_COORDINATES;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_ROOM_FINDER_SCHEDULE;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_ROOM_FINDER_SEARCH;
+import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_TICKET;
 import static de.tum.in.tumcampusapp.api.app.TUMCabeClient.API_WIFI_HEATMAP;
 
 public interface TUMCabeAPIService {
@@ -203,4 +207,10 @@ public interface TUMCabeAPIService {
 
     @GET(API_NEWS + "alert")
     Observable<NewsAlert> getNewsAlert();
+
+    @GET(API_EVENTS + "list")
+    Call<List<Event>> getEvents();
+
+    @GET(API_EVENTS + API_TICKET + "my")
+    Call<List<Ticket>> getTickets();
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -37,6 +37,8 @@ import de.tum.in.tumcampusapp.component.ui.news.model.News;
 import de.tum.in.tumcampusapp.component.ui.news.model.NewsAlert;
 import de.tum.in.tumcampusapp.component.ui.news.model.NewsSources;
 import de.tum.in.tumcampusapp.component.ui.studycard.model.StudyCard;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
 import de.tum.in.tumcampusapp.component.ui.tufilm.model.Kino;
 import de.tum.in.tumcampusapp.utils.Const;
 import de.tum.in.tumcampusapp.utils.Utils;
@@ -84,6 +86,8 @@ public final class TUMCabeClient {
     static final String API_KINOS = "kino/";
     static final String API_CARD = "cards/";
     static final String API_NEWS = "news/";
+    static final String API_EVENTS = "event/";
+    static final String API_TICKET = "ticket/";
 
     private static TUMCabeClient instance;
     private final TUMCabeAPIService service;
@@ -318,10 +322,20 @@ public final class TUMCabeClient {
     public List<News> getNews(String lastNewsId) throws IOException {
         return service.getNews(lastNewsId).execute().body();
     }
+
     public List<NewsSources> getNewsSources() throws IOException {
         return service.getNewsSources().execute().body();
     }
+
     public Observable<NewsAlert> getNewsAlert(){
         return service.getNewsAlert();
+    }
+
+    public List<Event> getEvents() throws IOException {
+        return service.getEvents().execute().body();
+    }
+
+    public List<Ticket> getTickets() throws IOException {
+        return service.getTickets().execute().body();
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -1,0 +1,70 @@
+package de.tum.in.tumcampusapp.component.ui.ticket;
+
+import android.content.Context;
+import android.util.SparseArray;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
+import de.tum.in.tumcampusapp.component.ui.overview.card.ProvidesCard;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
+import de.tum.in.tumcampusapp.utils.Utils;
+
+import static de.tum.in.tumcampusapp.utils.CacheManager.VALIDITY_ONE_DAY;
+
+public class EventsController implements ProvidesCard {
+
+    private static final int TIME_TO_SYNC = VALIDITY_ONE_DAY;
+    private final Context context;
+
+    // TODO: replace by database connection (@Dao classes etc.; see NewDao etc. for reference)
+    private SparseArray<Event> eventsMap = new SparseArray<>();
+
+    /**
+     * Constructor, open/create database, create table if necessary
+     *
+     * @param context Context
+     */
+    public EventsController(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Download events from external interface (JSON)
+     *
+     * @param force True to force download over normal sync period, else false
+     */
+    public void downloadFromExternal(boolean force) {
+        TUMCabeClient api = TUMCabeClient.getInstance(context);
+
+        // Load all events
+        try {
+            List<Event> events = api.getEvents();
+
+            // Add events to map
+            for (Event event : events){
+                eventsMap.put(event.getId(), event);
+            }
+        } catch (IOException e) {
+            Utils.log(e);
+        }
+
+        // TODO: remove this (only to test server calls)
+        try {
+            List<Ticket> tickets = api.getTickets();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onRequestCard(@NotNull Context context) {
+        // TODO
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/model/Event.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/model/Event.kt
@@ -1,0 +1,28 @@
+package de.tum.`in`.tumcampusapp.component.ui.ticket.model
+
+import android.arch.persistence.room.Entity
+import android.arch.persistence.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
+import java.util.*
+
+/**
+ * Events
+ *
+ * @param id      Event-ID
+ * @param image   Image url e.g. http://www.tu-film.de/img/film/poster/Fack%20ju%20Ghte.jpg
+ * @param title   Title
+ * @param description Description
+ * @param locality Locality
+ * @param date    Date
+ * @param link    Url, e.g. http://www.in.tum.de
+ */
+@Entity
+data class Event(@PrimaryKey
+                @SerializedName("event")
+                var id: Int = 0,
+                var image: String = "",
+                var title: String = "",
+                var description: String = "",
+                var locality: String = "",
+                var date: Date = Date(),
+                var link:  String = "")

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/model/Ticket.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/model/Ticket.kt
@@ -1,0 +1,19 @@
+package de.tum.`in`.tumcampusapp.component.ui.ticket.model
+
+import android.arch.persistence.room.Entity
+import android.arch.persistence.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Ticket
+ *
+ * @param event  Event
+ * @param code   code
+ * @param type   Type
+ */
+@Entity
+data class Ticket(@PrimaryKey
+                 @SerializedName("ticket")
+                 var event: Event,
+                 var code: String = "",
+                 var type: TicketType)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/model/TicketType.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/model/TicketType.kt
@@ -1,0 +1,19 @@
+package de.tum.`in`.tumcampusapp.component.ui.ticket.model
+
+import android.arch.persistence.room.Entity
+import android.arch.persistence.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Ticket
+ *
+ * @param id      Ticket-ID
+ * @param price   Price
+ * @param price   Description
+ */
+@Entity
+data class TicketType(@PrimaryKey
+                  @SerializedName("tickettype")
+                  var id: Int = 0,
+                  var price: Double = 0.toDouble(),
+                  var description: String = "")

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -19,6 +19,7 @@ import de.tum.`in`.tumcampusapp.component.ui.news.repository.KinoLocalRepository
 import de.tum.`in`.tumcampusapp.component.ui.news.repository.KinoRemoteRepository
 import de.tum.`in`.tumcampusapp.component.ui.news.repository.TopNewsRemoteRepository
 import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
+import de.tum.`in`.tumcampusapp.component.ui.ticket.EventsController
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.CacheManager
 import de.tum.`in`.tumcampusapp.utils.Const
@@ -93,11 +94,12 @@ class DownloadService : JobIntentService() {
      * @return if all downloads were successful
      */
     private fun downloadAll(force: Boolean): Boolean {
+        val eventsSuccess = downloadEvents(force)
         val cafeSuccess = downloadCafeterias(force)
         val kinoSuccess = downloadKino(force)
         val newsSuccess = downloadNews(force)
         val topNewsSuccess = downloadTopNews()
-        return cafeSuccess && kinoSuccess && newsSuccess && topNewsSuccess
+        return cafeSuccess && kinoSuccess && newsSuccess && topNewsSuccess && eventsSuccess
     }
 
     private fun downloadCafeterias(force: Boolean): Boolean {
@@ -114,6 +116,11 @@ class DownloadService : JobIntentService() {
 
     private fun downloadNews(force: Boolean): Boolean {
         NewsController(this).downloadFromExternal(force)
+        return true
+    }
+
+    private fun downloadEvents(force: Boolean): Boolean {
+        EventsController(this).downloadFromExternal(force)
         return true
     }
 
@@ -177,6 +184,7 @@ class DownloadService : JobIntentService() {
                 Utils.logv("Handle action <$action>")
 
                 when (action) {
+                    Const.EVENTS -> success = service.downloadEvents(force)
                     Const.NEWS -> success = service.downloadNews(force)
                     Const.CAFETERIAS -> success = service.downloadCafeterias(force)
                     Const.KINO -> success = service.downloadKino(force)

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/Const.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/Const.kt
@@ -21,6 +21,7 @@ object Const {
     const val HIDE_WIZARD_ON_STARTUP = "hide_wizard_on_startup"
     const val LRZ_ID = "lrz_id"
     const val NEWS = "news"
+    const val EVENTS = "events"
     const val KINO = "kino"
     const val STUDY_ROOM_GROUP_ID = "study_room_group_id"
     const val ROLE = "card_role"


### PR DESCRIPTION
I started working on the client side server calls. I implemented the methods getTickets() and getEvents(). I have verified them with a local server using the static API endpoints.

I copied the data classes Event, Ticket and TicketType from the Eventsoverview branch to be able to test my code.

Some open questions for me are:

1. Should we use a controller like in NewsController or a ViewModel as e.g. in KinoViewModel to manage the data?
2. I saw that for other components @Dao objects are used. As I understand it, the data is downloaded from the server and saved in a local database. I guess, we should also use a local database for events, right? 
Currently, I save the donwloaded data in attributes in EventsController. Can I use this approach and add the local database later?
3. I did not really understand how to pass parameters in server calls. There are multiple options like Path for including parameters in the url or Body for passing objects. The following call expects two parameters which are not part of the URL
GET api/event/ticket/validate

Parameters:

    event_id (required) -> event that the ticket is associated with
    code (required) -> ticket code

Response { "valid": true }

How should I pass these parameters?
4. Related to 3: On the backend the methods get a $post and a $params parameter. What is the difference there?