### PR TITLE
Fix text color of items in study rooms spinner

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/studyroom/StudyRoomsActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/studyroom/StudyRoomsActivity.java
@@ -78,19 +78,27 @@ public class StudyRoomsActivity extends ActivityForLoadingInBackground<Void, Voi
         SpinnerAdapter adapterCafeterias =
                 new ArrayAdapter<StudyRoomGroup>(this, R.layout.simple_spinner_item_actionbar,
                                                  android.R.id.text1, mStudyRoomGroupList) {
+                    final LayoutInflater inflater = LayoutInflater.from(getContext());
+
                     @Override
                     public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent) {
-                        View v = LayoutInflater.from(parent.getContext())
-                                               .inflate(R.layout.simple_spinner_dropdown_item_actionbar,
-                                                        parent, false);
+                        View v = inflater.inflate(R.layout.simple_spinner_dropdown_item_actionbar,
+                                                  parent, false);
                         StudyRoomGroup studyRoomGroup = getItem(position);
 
-                        TextView name = v.findViewById(android.R.id.text1); // Set name
-                        TextView details = v.findViewById(android.R.id.text2); // Set detail
+                        TextView nameTextView = v.findViewById(android.R.id.text1);
+                        TextView detailsTextView = v.findViewById(android.R.id.text2);
 
                         if (studyRoomGroup != null) {
-                            name.setText(studyRoomGroup.getName());
-                            details.setText(studyRoomGroup.getDetails());
+                            String name = studyRoomGroup.getName();
+                            String details = studyRoomGroup.getDetails();
+
+                            nameTextView.setText(name);
+                            detailsTextView.setText(details);
+
+                            if (details.isEmpty()) {
+                                detailsTextView.setVisibility(View.GONE);
+                            }
                         }
 
                         return v;

--- a/app/src/main/res/layout/activity_cafeteria.xml
+++ b/app/src/main/res/layout/activity_cafeteria.xml
@@ -1,8 +1,9 @@
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                        xmlns:tools="http://schemas.android.com/tools"
-                                        android:id="@+id/drawer_layout"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="match_parent">
+<android.support.v4.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
     <!-- The main content view -->
     <LinearLayout
         android:layout_width="match_parent"
@@ -59,6 +60,8 @@
         </LinearLayout>
 
     </LinearLayout>
+
     <!-- The navigation drawer -->
     <include layout="@layout/navigation_drawer"/>
+
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_study_rooms.xml
+++ b/app/src/main/res/layout/activity_study_rooms.xml
@@ -1,5 +1,6 @@
 <android.support.v4.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
@@ -21,9 +22,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 android:background="@color/color_primary"
-                android:elevation="12dp"
-                android:theme="@style/ThemeOverlay.AppCompat.Dark"
-                tools:ignore="UnusedAttribute">
+                android:elevation="@dimen/material_default_elevation"
+                android:theme="@style/TumToolbar"
+                app:popupTheme="@style/TumToolbarPopUp">
 
                 <Spinner
                     android:id="@+id/spinnerToolbar"

--- a/app/src/main/res/layout/simple_spinner_dropdown_item_actionbar.xml
+++ b/app/src/main/res/layout/simple_spinner_dropdown_item_actionbar.xml
@@ -6,8 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="?android:attr/listPreferredItemHeight"
     android:background="@android:color/background_light"
-    android:clickable="true"
-    android:focusable="true"
     android:foreground="?android:selectableItemBackground"
     android:gravity="center_vertical"
     android:orientation="vertical"

--- a/app/src/main/res/layout/simple_spinner_dropdown_item_actionbar.xml
+++ b/app/src/main/res/layout/simple_spinner_dropdown_item_actionbar.xml
@@ -1,34 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              style="?android:attr/spinnerDropDownItemStyle"
-              android:layout_width="match_parent"
-              android:layout_height="?android:attr/listPreferredItemHeight"
-              android:background="#fff"
-              android:gravity="fill_horizontal"
-              android:orientation="vertical"
-              android:padding="10dp">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="?android:attr/spinnerDropDownItemStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?android:attr/listPreferredItemHeight"
+    android:background="@android:color/background_light"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?android:selectableItemBackground"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="10dp">
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
         <TextView
             android:id="@android:id/text1"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:ellipsize="marquee"
+            android:singleLine="true"
             android:textSize="16sp"
-            android:singleLine="true"/>
+            tools:text="Text 1"/>
 
         <TextView
             android:id="@+id/distance"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="marquee"
             android:gravity="end"
+            android:singleLine="true"
             android:textSize="14sp"
-            android:singleLine="true"/>
+            tools:text="Distance"/>
+
     </LinearLayout>
 
     <TextView
@@ -36,6 +45,9 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:ellipsize="marquee"
+        android:singleLine="true"
         android:textSize="12sp"
-        android:singleLine="true"/>
+        tools:text="Text 2"
+        tools:visibility="gone"/>
+
 </LinearLayout>


### PR DESCRIPTION
In a previous commit, I broke the spinner in `StudyRoomActivity` so that it would display light text on a light background. This is now fixed. 

I also used this opportunity to add a ripple effect to the spinner, giving the user visual feedback on item selection.