### PR TITLE
Fix text in tuition fees card

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesActivity.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.api.tumonline.TUMOnlineConst;
 import de.tum.in.tumcampusapp.component.other.generic.activity.ActivityForAccessingTumOnline;
+import de.tum.in.tumcampusapp.component.tumui.tutionfees.model.Tuition;
 import de.tum.in.tumcampusapp.component.tumui.tutionfees.model.TuitionList;
 import de.tum.in.tumcampusapp.utils.DateUtils;
 
@@ -52,16 +53,10 @@ public class TuitionFeesActivity extends ActivityForAccessingTumOnline<TuitionLi
      */
     @Override
     public void onFetch(TuitionList tuitionList) {
-        String amount = tuitionList.getTuitions().get(0).getSoll();
-        float floatAmount = 0f;
+        Tuition tuition = tuitionList.getTuitions().get(0);
 
-        try {
-            String dotSeparatedAmount = amount.replace(",", ".");
-            floatAmount = Float.parseFloat(dotSeparatedAmount);
-        } catch (NumberFormatException ignored) {}
-
-        String amountText = String.format(Locale.getDefault(), "%.2f", floatAmount);
-        amountTextView.setText(String.format("%s €", amountText));
+        String amountText = tuition.getOutstandingBalanceText();
+        amountTextView.setText(amountText);
 
         Date deadline = DateUtils.getDate(tuitionList.getTuitions()
                                                  .get(0)
@@ -73,7 +68,7 @@ public class TuitionFeesActivity extends ActivityForAccessingTumOnline<TuitionLi
                                             .getSemesterBez()
                                             .toUpperCase(Locale.getDefault()));
 
-        if (floatAmount == 0) {
+        if (tuition.getOutstandingBalance() == 0) {
             amountTextView.setTextColor(getResources().getColor(R.color.sections_green));
         } else {
             // check if the deadline is less than a week from now

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.java
@@ -83,11 +83,12 @@ public class TuitionFeesCard extends NotificationAwareCard {
                                              .parse(mTuition.getSoll())
                                              .doubleValue();
 
-                balanceStr = String.format(Locale.GERMAN, "Value of a: %.2f", balance);
-            } catch (ParseException ignore) {
-            }
-            addedViews.add(addTextView(viewHolder.itemView.getContext()
-                                                          .getString(R.string.amount_dots) + ' ' + balanceStr + '€'));
+                balanceStr = String.format(Locale.GERMAN, "%.2f", balance);
+            } catch (ParseException ignore) {}
+
+            String textWithPlaceholder = viewHolder.itemView.getContext().getString(R.string.amount_dots_card);
+            String cardText = String.format(Locale.getDefault(), textWithPlaceholder, balanceStr);
+            addedViews.add(addTextView(cardText));
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.java
@@ -15,8 +15,6 @@ import android.view.ViewGroup;
 import android.widget.RemoteViews;
 
 import java.text.DateFormat;
-import java.text.NumberFormat;
-import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -77,17 +75,9 @@ public class TuitionFeesCard extends NotificationAwareCard {
                                     .format(d);
             addedViews.add(addTextView(String.format(getContext().getString(R.string.reregister_todo), date)));
 
-            String balanceStr = mTuition.getSoll();
-            try {
-                Double balance = NumberFormat.getInstance(Locale.GERMAN)
-                                             .parse(mTuition.getSoll())
-                                             .doubleValue();
-
-                balanceStr = String.format(Locale.GERMAN, "%.2f", balance);
-            } catch (ParseException ignore) {}
-
-            String textWithPlaceholder = viewHolder.itemView.getContext().getString(R.string.amount_dots_card);
-            String cardText = String.format(Locale.getDefault(), textWithPlaceholder, balanceStr);
+            String textWithPlaceholder = getContext().getString(R.string.amount_dots_card);
+            String cardText = String.format(
+                    Locale.getDefault(), textWithPlaceholder, mTuition.getOutstandingBalanceText());
             addedViews.add(addTextView(cardText));
         }
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/model/Tuition.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/model/Tuition.kt
@@ -36,7 +36,7 @@ data class Tuition(@field:Element(name = "frist")
         get() {
             return try {
                 val amountText = String.format(Locale.getDefault(), "%.2f", outstandingBalance)
-                return "$amountText€"
+                return "$amountText €"
             } catch (e: ParseException) {
                 soll
             }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/model/Tuition.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/model/Tuition.kt
@@ -2,6 +2,9 @@ package de.tum.`in`.tumcampusapp.component.tumui.tutionfees.model
 
 import org.simpleframework.xml.Element
 import org.simpleframework.xml.Root
+import java.text.NumberFormat
+import java.text.ParseException
+import java.util.*
 
 /**
  * Class holding tuition information.
@@ -16,4 +19,27 @@ data class Tuition(@field:Element(name = "frist")
                    @field:Element(name = "semester_bezeichnung")
                    var semesterBez: String = "",
                    @field:Element(name = "soll")
-                   var soll: String = "")
+                   var soll: String = "") {
+
+    val outstandingBalance: Float
+        get() {
+            return try {
+                NumberFormat.getInstance(Locale.GERMAN)
+                        .parse(soll)
+                        .toFloat()
+            } catch (e: ParseException) {
+                0f
+            }
+        }
+
+    val outstandingBalanceText: String
+        get() {
+            return try {
+                val amountText = String.format(Locale.getDefault(), "%.2f", outstandingBalance)
+                return "$amountText€"
+            } catch (e: ParseException) {
+                soll
+            }
+        }
+
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -176,6 +176,7 @@
     <!-- Tuition fees -->
     <string name="amount_dots">Offener Betrag</string>
     <string name="deadline_dots">Deadline:</string>
+    <string name="amount_dots_card">Offener Betrag: %s</string>
 
     <!-- Persons -->
     <string name="no_search_result">Keine Suchergebnisse</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="amount_dots">Outstanding balance</string>
     <string name="deadline_dots">Deadline:</string>
 
+    <string name="amount_dots_card">Outstanding balance: %s€</string>
+
     <!-- Persons -->
     <string name="no_search_result">No search result</string>
     <string name="no_person_set">No person set!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,8 +180,7 @@
     <!-- Tuition fees -->
     <string name="amount_dots">Outstanding balance</string>
     <string name="deadline_dots">Deadline:</string>
-
-    <string name="amount_dots_card">Outstanding balance: %s€</string>
+    <string name="amount_dots_card">Outstanding balance: %s</string>
 
     <!-- Persons -->
     <string name="no_search_result">No search result</string>


### PR DESCRIPTION
## Issue

This fixes wrong formatting of the outstanding balance in `TuitionFeesCard`. It also unifies the formatting across `TuitionFeesCard`and `TuitionFeesActivity`.

## Screenshot

Before
![screenshot_20180604-181648](https://user-images.githubusercontent.com/11819826/40930394-e1211afa-6827-11e8-937a-e3e77e88544c.png)

After
![screenshot_20180604-184851](https://user-images.githubusercontent.com/11819826/40930447-fecd1b1c-6827-11e8-99d4-e155e6c0d0c6.png)
(It uses a comma, because my device is set to English.)
