### PR TITLE
disable crashlytics for debug and -dev builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,11 @@ android {
             minifyEnabled true
             useProguard true
         }
-        debug.debuggable true
-        debug.testCoverageEnabled true
         release.debuggable false
+        debug {
+            debuggable true
+            testCoverageEnabled true
+        }
     }
     defaultConfig {
         applicationId "de.tum.in.tumcampus"
@@ -67,7 +69,6 @@ android {
         androidTest.assets.srcDirs += files("$projectDir/src/test/java".toString())
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
-
     dataBinding {
         enabled = true
     }
@@ -87,6 +88,7 @@ configurations.all {
 }
 
 dependencies {
+
     // Support Libraries
     implementation "com.android.support:cardview-v7:$androidSupportVersion"
     implementation "com.android.support:design:$androidSupportVersion"
@@ -98,8 +100,8 @@ dependencies {
     // Android arch components
     implementation "android.arch.persistence.room:rxjava2:$roomVersion"
     implementation "android.arch.persistence.room:runtime:$roomVersion"
-    implementation "android.arch.lifecycle:runtime:1.1.1"
-    implementation "android.arch.lifecycle:extensions:1.1.1"
+    implementation 'android.arch.lifecycle:runtime:1.1.1'
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
     annotationProcessor "android.arch.lifecycle:compiler:$roomVersion"
     annotationProcessor "android.arch.persistence.room:compiler:$roomVersion"
 
@@ -110,9 +112,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-base:$firebaseVersion"
     implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
     implementation "com.google.android.gms:play-services-location:$firebaseVersion"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.3@aar') {
-        transitive = true
-    }
+    releaseImplementation 'com.crashlytics.sdk.android:crashlytics:2.9.3'
 
     // Helpers
     implementation 'net.danlew:android.joda:2.9.9.2'
@@ -122,7 +122,7 @@ dependencies {
         exclude group: 'xpp3', module: 'xpp3'
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'com.trello.rxlifecycle2:rxlifecycle:2.2.1'
     implementation 'com.trello.rxlifecycle2:rxlifecycle-android-lifecycle:2.2.1'
     implementation 'com.github.franmontiel:PersistentCookieJar:v1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,9 @@ dependencies {
     implementation "com.google.android.gms:play-services-base:$firebaseVersion"
     implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
     implementation "com.google.android.gms:play-services-location:$firebaseVersion"
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.2'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.3@aar') {
+        transitive = true
+    }
 
     //Helpers
     implementation 'net.danlew:android.joda:2.9.9.2'

--- a/app/src/main/java/de/tum/in/tumcampusapp/App.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/App.java
@@ -1,17 +1,26 @@
 package de.tum.in.tumcampusapp;
-import android.app.Application;
-import android.util.Log;
 
+import android.app.Application;
+
+import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.core.CrashlyticsCore;
 import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
+
+import io.fabric.sdk.android.Fabric;
 
 public class App extends Application {
 
     @Override
     public void onCreate() {
         super.onCreate();
+        setupPicasso();
+        setupCrashlytics();
+    }
+
+    private void setupPicasso() {
         Picasso.Builder builder = new Picasso.Builder(this);
-        builder.downloader(new OkHttp3Downloader(this,Integer.MAX_VALUE));
+        builder.downloader(new OkHttp3Downloader(this, Integer.MAX_VALUE));
 
         Picasso built = builder.build();
         built.setLoggingEnabled(true);
@@ -23,4 +32,16 @@ public class App extends Application {
         Picasso.setSingletonInstance(built);
     }
 
+    /**
+     * Disable crashlytics for debug builds, or non-release builds indicated by the "dev" suffix
+     */
+    private void setupCrashlytics() {
+
+        Crashlytics crashlyticsKit = new Crashlytics.Builder()
+                .core(new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG || BuildConfig.VERSION_NAME.contains("dev"))
+                                                   .build())
+                .build();
+
+        Fabric.with(this, crashlyticsKit);
+    }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/App.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/App.java
@@ -2,12 +2,8 @@ package de.tum.in.tumcampusapp;
 
 import android.app.Application;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
 import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
-
-import io.fabric.sdk.android.Fabric;
 
 public class App extends Application {
 
@@ -15,10 +11,9 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
         setupPicasso();
-        setupCrashlytics();
     }
 
-    private void setupPicasso() {
+    protected void setupPicasso() {
         Picasso.Builder builder = new Picasso.Builder(this);
         builder.downloader(new OkHttp3Downloader(this, Integer.MAX_VALUE));
 
@@ -30,18 +25,5 @@ public class App extends Application {
         }
 
         Picasso.setSingletonInstance(built);
-    }
-
-    /**
-     * Disable crashlytics for debug builds, or non-release builds indicated by the "dev" suffix
-     */
-    private void setupCrashlytics() {
-
-        Crashlytics crashlyticsKit = new Crashlytics.Builder()
-                .core(new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG || BuildConfig.VERSION_NAME.contains("dev"))
-                                                   .build())
-                .build();
-
-        Fabric.with(this, crashlyticsKit);
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/TestApp.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/TestApp.java
@@ -1,9 +1,12 @@
 package de.tum.in.tumcampusapp;
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("Registered")
 public class TestApp extends App {
 
     @Override
-    protected void initPicasso() {
+    protected void setupPicasso() {
         //nothing to do
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.fabric.tools:gradle:1.25.1'
+        classpath 'io.fabric.tools:gradle:1.25.4'
     }
 }
 


### PR DESCRIPTION
this fixes #824 

@kordianbruck curiously, I'm still getting messages in logcat:
```
de.tum.in.tumcampus I/CrashlyticsCore: Crashlytics report upload complete: 5B199C5701A0-0001-3C87-B9ADEF9F5A41
```

I followed [the official guide](https://docs.fabric.io/android/crashlytics/build-tools.html), and verified the Crashlytics Kit `isDisabled == true`.
Maybe we need to check, if the debug messages still are shown in the dashboard...