### PR TITLE
Fix crash in TransportDetails

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVSymbolView.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVSymbolView.java
@@ -1,6 +1,7 @@
 package de.tum.in.tumcampusapp.component.ui.transportation;
 
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.Path;
@@ -16,12 +17,17 @@ import com.google.common.primitives.Ints;
  * Subclass of drawable that can draw a subway line icon
  */
 public class MVVSymbolView extends Drawable {
+
     private static final int[] S_LINE_COLOR = {
             0xff6db9df, 0xff8db335, 0xff7d187b, 0xffc1003c, 0, 0xff00915e, 0xff7f3229, 0xff1f1e21
     };
+
     private static final int[] U_LINE_COLOR = {
             0xff44723c, 0xffcc263c, 0xffe4721c, 0xff04a27c, 0xffa4721c, 0xff045ea4
     };
+
+    private static final int U_LINE_DEFAULT_COLOR = Color.GRAY;
+
     private final Paint mBgPaint;
     private final RectF mRect;
     private final int mTriangle;
@@ -67,8 +73,10 @@ public class MVVSymbolView extends Drawable {
                 } else if (num == 8) {
                     triangle = 2;
                     backgroundColor = 0xffeb6a27;
-                } else {
+                } else if (num != 0) {
                     backgroundColor = U_LINE_COLOR[num - 1];
+                } else {
+                    backgroundColor = U_LINE_DEFAULT_COLOR;
                 }
                 textColor = 0xfffcfefc;
                 break;


### PR DESCRIPTION
This fixes the following issue(s):
This fixes a crash that occurred when building the `MVVSymbolView`. Because the MVV API occasionally only returns "U" for a subway departure instead of the full symbol (e.g. "U3"), the app crashed while attempting to get the right subway line color for the departure. 

The fix simply provides a default subway line color for these cases. 