### PR TITLE
Fix bug that occasionally caused transport search results to be empty

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportController.java
@@ -337,7 +337,7 @@ public class TransportController implements ProvidesCard {
         String name = point.getString("name");
         String id = point.getJSONObject("ref")
                          .getString("id");
-        int quality = point.getInt("quality");
+        int quality = (point.has("quality")) ? point.getInt("quality") : 0;
         results.add(new StationResult(name, id, quality));
     }
 


### PR DESCRIPTION
This fixes the following issue(s):
This fixes a problem where the search results in `TransportActivity` would stay empty even if the user entered a valid query (e.g. “Marienplatz”). It occurred because the MVV API occasionally does not return the "quality" property of a search result, resulting in a JSONException in the app. 

The problem was fixed by providing 0 as a default value in case the "quality" property is missing. While this no longer allows us to sort search results based on how well they match with the query, it at least provides the user with some results.