### PR TITLE
Fix crashes when device is offline

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/ConnectivityInterceptor.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/ConnectivityInterceptor.kt
@@ -1,0 +1,23 @@
+package de.tum.`in`.tumcampusapp.api.app
+
+import android.content.Context
+import de.tum.`in`.tumcampusapp.api.app.exception.NoNetworkConnectionException
+import de.tum.`in`.tumcampusapp.utils.NetUtils
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class ConnectivityInterceptor(private val context: Context) : Interceptor {
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        if (!NetUtils.isConnected(context)) {
+            throw NoNetworkConnectionException()
+        }
+
+        return chain.proceed(request)
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/Helper.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/Helper.java
@@ -34,7 +34,7 @@ public final class Helper {
     private static final int HTTP_TIMEOUT = 25000;
     private static OkHttpClient client;
 
-    public static OkHttpClient getOkClient(Context c) {
+    public static OkHttpClient getOkHttpClient(Context c) {
         if (client != null) {
             return client;
         }
@@ -69,6 +69,8 @@ public final class Helper {
 
         //Add the device identifying header
         builder.addInterceptor(Helper.getDeviceInterceptor(c));
+
+        builder.addInterceptor(new ConnectivityInterceptor(c));
 
         builder.connectTimeout(Helper.HTTP_TIMEOUT, TimeUnit.MILLISECONDS);
         builder.readTimeout(Helper.HTTP_TIMEOUT, TimeUnit.MILLISECONDS);

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -94,7 +94,7 @@ public final class TUMCabeClient {
         Gson gson = new GsonBuilder().registerTypeAdapter(Date.class, new DateSerializer())
                                      .create();
         builder.addConverterFactory(GsonConverterFactory.create(gson));
-        builder.client(Helper.getOkClient(c));
+        builder.client(Helper.getOkHttpClient(c));
         service = builder.build()
                          .create(TUMCabeAPIService.class);
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/exception/NoNetworkConnectionException.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/exception/NoNetworkConnectionException.kt
@@ -1,0 +1,10 @@
+package de.tum.`in`.tumcampusapp.api.app.exception
+
+import java.io.IOException
+
+class NoNetworkConnectionException : IOException() {
+
+    override val message: String?
+        get() = "Device is not connected to the Internet"
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/NetUtils.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/NetUtils.java
@@ -31,7 +31,7 @@ public class NetUtils {
         cacheManager = new CacheManager(mContext);
 
         //Set our max wait time for each request
-        client = Helper.getOkClient(context);
+        client = Helper.getOkHttpClient(context);
     }
 
     public static Optional<JSONObject> downloadJson(Context context, String url) {

--- a/app/src/main/res/drawable/news_source_placeholder.xml
+++ b/app/src/main/res/drawable/news_source_placeholder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <size android:height="@dimen/compound_drawable_size" android:width="@dimen/compound_drawable_size"/>
+    <corners android:radius="2dp"/>
+    <solid android:color="@color/news_source_placeholder"/>
+</shape>

--- a/app/src/main/res/layout/card_news_item.xml
+++ b/app/src/main/res/layout/card_news_item.xml
@@ -1,5 +1,4 @@
-<android.support.v7.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/StandardCard">
 
@@ -17,7 +16,7 @@
             android:maxHeight="200dp"
             android:minHeight="50dp"
             android:scaleType="centerCrop"
-            android:src="@drawable/mvv_entire_net_icon"/>
+            android:src="@drawable/mvv_entire_net_icon" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -31,7 +30,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/info_title"
                 android:textSize="20sp"
-                tools:text="News title"/>
+                tools:text="News title" />
 
             <TextView
                 android:id="@+id/news_src_date"
@@ -39,15 +38,15 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/material_default_padding"
                 android:textSize="16sp"
-                tools:text="News source date"/>
+                tools:text="News source date" />
 
             <TextView
                 android:id="@+id/news_src_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="@dimen/material_default_padding"
-                android:drawableStart="@drawable/ic_facebook"
-                tools:text="News source title"/>
+                android:drawableStart="@drawable/news_source_placeholder"
+                tools:text="News source title" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,6 +24,8 @@
     <color name="github">#24292E</color>
     <color name="email">#757575</color>
 
+    <color name="news_source_placeholder">#E2E2E2</color>
+
     <!-- official TUM accent colors (style guide) -->
     <color name="tum_orange">#E37222</color>
     <color name="tum_green">#A2AD00</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,6 +8,8 @@
     <dimen name="material_corner_radius">2dp</dimen>
     <dimen name="material_default_elevation">12dp</dimen>
 
+    <dimen name="compound_drawable_size">16dp</dimen>
+
     <dimen name="padding_chat">2dp</dimen>
     <dimen name="padding_default">8dp</dimen>
     <dimen name="padding_small">4dp</dimen>


### PR DESCRIPTION
This fixes the following issue(s):
Performing requests with Retrofit while the device is offline used to result in exceptions. This occurred when the `DownloadService`was invoked in the background. 

This change adds a `ConnectivityInterceptor`, which checks whether the device is connected to the Internet (via `NetUtils`). If not, it throws a `NoNetworkConnectivityException`, which can be reacted to in Retrofit’s `onFailure()` callback.

This prevented any crashes in my tests. Please give it a thorough review.