### PR TITLE
Fix empty TUFilm screen

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeAPIService.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeAPIService.java
@@ -30,6 +30,7 @@ import de.tum.in.tumcampusapp.component.ui.news.model.NewsAlert;
 import de.tum.in.tumcampusapp.component.ui.news.model.NewsSources;
 import de.tum.in.tumcampusapp.component.ui.studycard.model.StudyCard;
 import de.tum.in.tumcampusapp.component.ui.tufilm.model.Kino;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import okhttp3.MultipartBody;
 import retrofit2.Call;
@@ -193,7 +194,7 @@ public interface TUMCabeAPIService {
     Observable<List<Cafeteria>> getCafeterias();
 
     @GET(API_KINOS + "{lastId}")
-    Observable<List<Kino>> getKinos(@Path("lastId") String lastId);
+    Flowable<List<Kino>> getKinos(@Path("lastId") String lastId);
 
     @GET(API_CARD)
     Call<List<StudyCard>> getStudyCards();

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -40,6 +40,7 @@ import de.tum.in.tumcampusapp.component.ui.studycard.model.StudyCard;
 import de.tum.in.tumcampusapp.component.ui.tufilm.model.Kino;
 import de.tum.in.tumcampusapp.utils.Const;
 import de.tum.in.tumcampusapp.utils.Utils;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -322,7 +323,7 @@ public final class TUMCabeClient {
         return service.getCafeterias();
     }
 
-    public Observable<List<Kino>> getKinos(String lastId) {
+    public Flowable<List<Kino>> getKinos(String lastId) {
         return service.getKinos(lastId);
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/repository/KinoRemoteRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/repository/KinoRemoteRepository.kt
@@ -2,12 +2,12 @@ package de.tum.`in`.tumcampusapp.component.ui.news.repository
 
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
 import de.tum.`in`.tumcampusapp.component.ui.tufilm.model.Kino
-import io.reactivex.Observable
+import io.reactivex.Flowable
 
 object KinoRemoteRepository {
 
     lateinit var tumCabeClient: TUMCabeClient
 
-    fun getAllKinos(lastId: String): Observable<List<Kino>> = tumCabeClient.getKinos(lastId)
+    fun getAllKinos(lastId: String): Flowable<List<Kino>> = tumCabeClient.getKinos(lastId)
 
 }


### PR DESCRIPTION
This fixes the following issue(s):
When users have not previously downloaded TUFilm movies and then did, the amount of movies caused problems with Observable. 

With this commit, we switch to Flowable for downloading TUFilm movies. It offers backpressure support and can thus handle large numbers of emitted items.