### PR TITLE
Rework WiFi scanning

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/service/BackgroundService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/BackgroundService.kt
@@ -2,6 +2,7 @@ package de.tum.`in`.tumcampusapp.service
 
 import android.content.Context
 import android.content.Intent
+import android.os.Looper
 import android.support.v4.app.JobIntentService
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
@@ -30,6 +31,8 @@ class BackgroundService : JobIntentService() {
             putExtra(Const.APP_LAUNCHES, appLaunches)
         }
         DownloadService.enqueueWork(baseContext, service)
+        Looper.prepare()
+        WifiScanHandler.getInstance().startRepetition(this)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
@@ -67,6 +67,7 @@ class ScanResultsAvailableReceiver : BroadcastReceiver() {
         val wifiScansEnabled = Utils.getSettingBool(context, Const.WIFI_SCANS_ALLOWED, false)
         var nextScanScheduled = false
 
+        val wifiScanHandler = WifiScanHandler.getInstance()
         wifiManager.scanResults.forEach { network ->
             if (network.SSID != Const.EDUROAM_SSID && network.SSID != Const.LRZ) {
                 return@forEach
@@ -91,6 +92,7 @@ class ScanResultsAvailableReceiver : BroadcastReceiver() {
             val minimumBattery = Utils.getSettingFloat(context, Const.WIFI_SCAN_MINIMUM_BATTERY_LEVEL, 50.0f)
 
             if (currentBattery > minimumBattery) {
+                wifiScanHandler.startRepetition(context)
                 Utils.log("WifiScanHandler rescheduled")
             } else {
                 Utils.log("WifiScanHandler stopped")

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
@@ -43,6 +43,8 @@ class ScanResultsAvailableReceiver : BroadcastReceiver() {
             return
         }
 
+        WifiScanHandler.getInstance().onScanFinished()
+
         //Check if wifi is turned on at all
         val wifiManager = context.applicationContext
                 .getSystemService(Context.WIFI_SERVICE) as WifiManager

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/WifiScanHandler.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/WifiScanHandler.kt
@@ -1,0 +1,54 @@
+package de.tum.`in`.tumcampusapp.service
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.os.Handler
+import de.tum.`in`.tumcampusapp.utils.Utils
+import java.util.*
+
+/**
+ * This class is responsible for starting repeating wifi scans.
+ * Its next schedule will be called at random. The upper and lower bound
+ * for the next schedule are defined by MIN_ AND MAX_TIME_PASSED_IN_SECONDS.
+ * The generator then randomly picks a number in this range as input for postDelayed
+ */
+
+class WifiScanHandler : Handler() {
+
+    fun startRepetition(context: Context) {
+        val interval = generateRandomScanInterval(MIN_TIME_PASSED_IN_SECONDS, MAX_TIME_PASSED_IN_SECONDS - MIN_TIME_PASSED_IN_SECONDS)
+        val periodicalScan = PeriodicalScan(context)
+        postDelayed(periodicalScan, interval.toLong())
+    }
+
+    private class PeriodicalScan(val context: Context) : Runnable {
+
+        override fun run() {
+            val wifiManager = context.applicationContext
+                    .getSystemService(Context.WIFI_SERVICE) as WifiManager
+            wifiManager.startScan()
+            Utils.log("WifiScanHandler started")
+        }
+
+    }
+
+    companion object {
+
+        private val INSTANCE = WifiScanHandler()
+
+        //Big range advised, e.g. 10s to 420s (7min), since there's a possibility for battery drain
+        private const val MIN_TIME_PASSED_IN_SECONDS = 5
+        private const val MAX_TIME_PASSED_IN_SECONDS = 420
+
+        fun getInstance() = INSTANCE.apply {
+            removeCallbacksAndMessages(null)
+        }
+
+        private fun generateRandomScanInterval(minimumSeconds: Int, range: Int): Int {
+            val random = Random()
+            return 1000 * minimumSeconds + random.nextInt(range * 1000)
+        }
+
+    }
+
+}


### PR DESCRIPTION
Follow up from #883

The current state wouldn't show the Eduroam card anymore, since we wouldn't do periodic scans anymore.
However this time, we start the `WifiScanHandler` exactly once from the `BackgroundService` instead of on each connectivity changed.
Additionally, aquire a `WifiLock` to hopefully properly fix #883