### PR TITLE
Fix unnecessary comma in grades list items

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.java
@@ -1,7 +1,6 @@
 package de.tum.in.tumcampusapp.component.tumui.grades;
 
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -56,14 +55,16 @@ public class ExamListAdapter extends SimpleStickyListHeadersAdapter<Exam> {
 
         Exam exam = infoList.get(position);
         if (exam != null) {
-            holder.tvName.setText(exam.getCourse());
-            holder.tvGrade.setText(exam.getGrade());
-            holder.gradeBackground.setTint(exam.getGradeColor(context));
+            holder.nameTextView.setText(exam.getCourse());
+            holder.gradeTextView.setText(exam.getGrade());
 
-            holder.tvDetails1.setText(String.format("%s: %s", context.getString(R.string.date), DF.format(exam.getDate())));
+            int gradeColor = exam.getGradeColor(context);
+            holder.gradeTextView.getBackground().setTint(gradeColor);
 
-            holder.tvDetails2.setText(String.format("%s: %s, " +
-                            "%s: %s",
+            holder.examDateTextView.setText(String.format(
+                    "%s: %s", context.getString(R.string.date), DF.format(exam.getDate())));
+
+            holder.additionalInfoTextView.setText(String.format("%s: %s, %s: %s",
                     context.getString(R.string.examiner), exam.getExaminer(),
                     context.getString(R.string.mode), exam.getModus()));
         }
@@ -73,17 +74,16 @@ public class ExamListAdapter extends SimpleStickyListHeadersAdapter<Exam> {
 
     static class ViewHolder {
 
-        TextView tvName;
-        TextView tvGrade;
-        TextView tvDetails1;
-        TextView tvDetails2;
-        Drawable gradeBackground;
+        TextView nameTextView;
+        TextView gradeTextView;
+        TextView examDateTextView;
+        TextView additionalInfoTextView;
 
         public ViewHolder(View itemView) {
-            tvName = itemView.findViewById(R.id.courseNameTextView);
-            tvGrade = itemView.findViewById(R.id.gradeTextView);
-            tvDetails1 = itemView.findViewById(R.id.examDateTextView);
-            gradeBackground = tvGrade.getBackground();
+            nameTextView = itemView.findViewById(R.id.courseNameTextView);
+            gradeTextView = itemView.findViewById(R.id.gradeTextView);
+            examDateTextView = itemView.findViewById(R.id.examDateTextView);
+            additionalInfoTextView = itemView.findViewById(R.id.additionalInfoTextView);
         }
 
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.java
@@ -46,22 +46,14 @@ public class ExamListAdapter extends SimpleStickyListHeadersAdapter<Exam> {
         ViewHolder holder;
         View view = convertView;
 
-        // find and init UI
         if (view == null) {
             view = mInflater.inflate(R.layout.activity_grades_listview, parent, false);
-            holder = new ViewHolder();
-            holder.tvName = view.findViewById(R.id.courseNameTextView);
-            holder.tvGrade = view.findViewById(R.id.gradeTextView);
-            holder.tvDetails1 = view.findViewById(R.id.examDateTextView);
-            holder.tvDetails2 = view.findViewById(R.id.examinerTextView);
-            holder.gradeBackground = context.getResources()
-                                            .getDrawable(R.drawable.grade_background);
-            holder.tvGrade.setBackground(holder.gradeBackground);
+            holder = new ViewHolder(view);
             view.setTag(holder);
         } else {
             holder = (ViewHolder) view.getTag();
         }
-        // fill UI with data
+
         Exam exam = infoList.get(position);
         if (exam != null) {
             holder.tvName.setText(exam.getCourse());
@@ -71,19 +63,28 @@ public class ExamListAdapter extends SimpleStickyListHeadersAdapter<Exam> {
             holder.tvDetails1.setText(String.format("%s: %s", context.getString(R.string.date), DF.format(exam.getDate())));
 
             holder.tvDetails2.setText(String.format("%s: %s, " +
-                                                    "%s: %s",
-                                                    context.getString(R.string.examiner), exam.getExaminer(),
-                                                    context.getString(R.string.mode), exam.getModus()));
+                            "%s: %s",
+                    context.getString(R.string.examiner), exam.getExaminer(),
+                    context.getString(R.string.mode), exam.getModus()));
         }
 
         return view;
     }
 
     static class ViewHolder {
+
+        TextView tvName;
+        TextView tvGrade;
         TextView tvDetails1;
         TextView tvDetails2;
-        TextView tvGrade;
-        TextView tvName;
         Drawable gradeBackground;
+
+        public ViewHolder(View itemView) {
+            tvName = itemView.findViewById(R.id.courseNameTextView);
+            tvGrade = itemView.findViewById(R.id.gradeTextView);
+            tvDetails1 = itemView.findViewById(R.id.examDateTextView);
+            gradeBackground = tvGrade.getBackground();
+        }
+
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.java
@@ -68,7 +68,7 @@ public class ExamListAdapter extends SimpleStickyListHeadersAdapter<Exam> {
             holder.tvGrade.setText(exam.getGrade());
             holder.gradeBackground.setTint(exam.getGradeColor(context));
 
-            holder.tvDetails1.setText(String.format("%s: %s, ", context.getString(R.string.date), DF.format(exam.getDate())));
+            holder.tvDetails1.setText(String.format("%s: %s", context.getString(R.string.date), DF.format(exam.getDate())));
 
             holder.tvDetails2.setText(String.format("%s: %s, " +
                                                     "%s: %s",

--- a/app/src/main/res/layout/activity_grades_listview.xml
+++ b/app/src/main/res/layout/activity_grades_listview.xml
@@ -32,7 +32,7 @@
             tools:text="Exam date"/>
 
         <TextView
-            android:id="@+id/examinerTextView"
+            android:id="@+id/additionalInfoTextView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Examiner"/>


### PR DESCRIPTION
In list items in `GradesActivity`, there was an additional comma at the end of the line. This commit removes it and also makes minor code improvements to the ViewHolder initialization.