### PR TITLE
Fix exception occurring in Picasso image loading

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 import android.support.v4.app.NotificationCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
@@ -139,9 +141,13 @@ public class NewsCard extends NotificationAwareCard {
         final String imgURL = mNews.getImage();
         if (!imgURL.trim().isEmpty() && !"null".equals(imgURL)) {
             Utils.log(imgURL);
-            Picasso.get()
-                    .load(imgURL)
-                    .into(remoteViews, R.id.widgetCardImageView, new int[]{appWidgetId});
+
+            Handler uiHandler = new Handler(Looper.getMainLooper());
+            uiHandler.post(() -> {
+                Picasso.get()
+                        .load(imgURL)
+                        .into(remoteViews, R.id.widgetCardImageView, new int[] {appWidgetId});
+            });
         }
         return remoteViews;
     }


### PR DESCRIPTION
This commit fixes an exception that occurred when loading an image using Picasso in a widget service. 