### PR TITLE
Fixes for Roomfinder behavior

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.java
@@ -171,7 +171,9 @@ public class NextLectureCard extends NotificationAwareCard {
 
             // Handle location
             item.location = calendarItem.getEventLocation();
+            // This is the location in a format which is useful for searches:
             item.locationForSearch = calendarItem.getLocation();
+
             lectures.add(item);
         }
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.java
@@ -110,7 +110,7 @@ public class NextLectureCard extends NotificationAwareCard {
             mLocation.setText(item.location);
             mLocation.setOnClickListener(v -> {
                 Intent i = new Intent(getContext(), RoomFinderActivity.class);
-                i.putExtra(SearchManager.QUERY, item.location);
+                i.putExtra(SearchManager.QUERY, item.locationForSearch);
                 getContext().startActivity(i);
             });
         }
@@ -171,6 +171,7 @@ public class NextLectureCard extends NotificationAwareCard {
 
             // Handle location
             item.location = calendarItem.getEventLocation();
+            item.locationForSearch = calendarItem.getLocation();
             lectures.add(item);
         }
     }
@@ -180,6 +181,7 @@ public class NextLectureCard extends NotificationAwareCard {
         Date start;
         Date end;
         String location;
+        String locationForSearch;
     }
 
     @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderActivity.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
@@ -70,9 +72,10 @@ public class RoomFinderActivity extends ActivityForSearchingInBackground<List<Ro
 
     @Override
     protected Optional<List<RoomFinderRoom>> onSearchInBackground(String query) {
+        Utils.log("Starting Room Finder query with: " + query+ "  , "+ userRoomSearchMatching(query));
+
         try {
-            List<RoomFinderRoom> rooms = TUMCabeClient.getInstance(this)
-                                                      .fetchRooms(query);
+            List<RoomFinderRoom> rooms = TUMCabeClient.getInstance(this).fetchRooms(userRoomSearchMatching(query));
             return Optional.of(rooms);
         } catch (IOException e) {
             Utils.log(e);
@@ -134,5 +137,17 @@ public class RoomFinderActivity extends ActivityForSearchingInBackground<List<Ro
             }
         }
         return roomList;
+    }
+
+    private static String userRoomSearchMatching(String roomSearchQuery) {
+        Pattern pattern = Pattern.compile("(\\w+(?:\\.\\w+)+)|(\\w+\\d+)");
+        //Pattern pattern = Pattern.compile("(\\w+(?:\\.\\w+)+)|([\\d]+)|([\\w]+)");
+        Matcher matcher = pattern.matcher(roomSearchQuery);
+
+        if (matcher.find()) {
+            return matcher.group();
+        } else {
+            return roomSearchQuery;
+        }
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderActivity.java
@@ -72,10 +72,9 @@ public class RoomFinderActivity extends ActivityForSearchingInBackground<List<Ro
 
     @Override
     protected Optional<List<RoomFinderRoom>> onSearchInBackground(String query) {
-        Utils.log("Starting Room Finder query with: " + query+ "  , "+ userRoomSearchMatching(query));
-
         try {
-            List<RoomFinderRoom> rooms = TUMCabeClient.getInstance(this).fetchRooms(userRoomSearchMatching(query));
+            List<RoomFinderRoom> rooms = TUMCabeClient.getInstance(this)
+                    .fetchRooms(userRoomSearchMatching(query));
             return Optional.of(rooms);
         } catch (IOException e) {
             Utils.log(e);
@@ -139,9 +138,17 @@ public class RoomFinderActivity extends ActivityForSearchingInBackground<List<Ro
         return roomList;
     }
 
+    /**
+     * Distinguishes between some room searches, eg. MW 2001 or MI 01.15.069 and takes the
+     * number part so that the search can return (somewhat) meaningful results
+     * (Temporary and non-optimal)
+     *
+     * @return a new query or the original one if nothing was matched
+     */
     private static String userRoomSearchMatching(String roomSearchQuery) {
+        // Matches the number part if the String is composed of two words, probably wrong:
         Pattern pattern = Pattern.compile("(\\w+(?:\\.\\w+)+)|(\\w+\\d+)");
-        //Pattern pattern = Pattern.compile("(\\w+(?:\\.\\w+)+)|([\\d]+)|([\\w]+)");
+
         Matcher matcher = pattern.matcher(roomSearchQuery);
 
         if (matcher.find()) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderActivity.java
@@ -147,7 +147,12 @@ public class RoomFinderActivity extends ActivityForSearchingInBackground<List<Ro
      */
     private static String userRoomSearchMatching(String roomSearchQuery) {
         // Matches the number part if the String is composed of two words, probably wrong:
+
         Pattern pattern = Pattern.compile("(\\w+(?:\\.\\w+)+)|(\\w+\\d+)");
+        /*  First group captures numbers with dots, like the 01.15.069 part from 'MI 01.15.069'
+        (This is the best search format for MI room numbers)
+        The second group captures numbers and mixed formats with letters, like 'MW2001'
+        Only the first match will be returned  */
 
         Matcher matcher = pattern.matcher(roomSearchQuery);
 


### PR DESCRIPTION
Clicking on room in next lecture cards works now, searching for room with multiple words (eg. MW 2001) works also through some regex magic.

## Issue

This fixes the following issue(s):
https://github.com/TCA-Team/TumCampusApp/issues/562 (temporarely and only for some cases) and the issue with clicking on rooms in next lecture card.

## Screenshot

## Why this is useful for all students

