### PR TITLE
implemented display of ticket types in BuyTicketActivity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/BuyTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/BuyTicketActivity.java
@@ -3,11 +3,15 @@ package de.tum.in.tumcampusapp.component.ui.ticket;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import de.tum.in.tumcampusapp.R;
@@ -41,20 +45,28 @@ public class BuyTicketActivity extends BaseActivity {
         int eventId = getIntent().getIntExtra("eventID", 0);
 
         Event event = eventsController.getEventById(eventId);
-        // TODO: get ticket from server here as soon as the backend implementation is ready
-        // Create ticket locally for now for testing purposes
-        //Ticket ticket = eventsController.getTicketByEventId(eventId);
-        Ticket ticket = new Ticket(42, eventId, "4242424242424242kjladhslfkjhasdf",
-                0, false);
-        TicketType ticketType = eventsController.getTicketTypeById(ticket.getTicketTypeId());
+        ArrayList<TicketType> ticketTypes = (ArrayList<TicketType>) eventsController.getTicketTypesByEventId(eventId);
+        TicketType chosenTicketType = null;
 
+        if (ticketTypes != null){
+            Spinner ticketTypeSpinner = findViewById(R.id.ticket_type_spinner);
+
+            ArrayAdapter adapter = new ArrayAdapter(this,
+                    android.R.layout.simple_spinner_item, ticketTypes);
+            ticketTypeSpinner.setAdapter(adapter);
+        }else{
+            // TODO: no internet connection, what to do then
+        }
+
+        // TODO: get ticket type from server here as soon as the backend implementation is ready
+        // Create ticket locally for now for testing purposes
         String eventString = event.getTitle();
         String locationString = event.getLocality();
         String dateString = new SimpleDateFormat("yyyy-MM-dd hh:mm", Locale.GERMANY).
                 format(event.getDate());
-        String priceString = new DecimalFormat("#.00").format(ticketType.getPrice())
+        String priceString = new DecimalFormat("#.00").format(chosenTicketType.getPrice())
                 + " €";
-        String ticketTypeString = ticketType.getDescription();
+        String ticketTypeString = chosenTicketType.getDescription();
 
         eventView.append(eventString);
         locationView.append(locationString);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/BuyTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/BuyTicketActivity.java
@@ -3,6 +3,7 @@ package de.tum.in.tumcampusapp.component.ui.ticket;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.Spinner;
@@ -17,14 +18,14 @@ import java.util.Locale;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.component.other.generic.activity.BaseActivity;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
-import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketType;
-
 
 public class BuyTicketActivity extends BaseActivity {
 
     private EventsController eventsController;
     private int eventId;
+
+    private Spinner ticketTypeSpinner;
 
     private List<TicketType> ticketTypes;
 
@@ -35,20 +36,21 @@ public class BuyTicketActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         eventsController = new EventsController(this);
-
-        Button paymentButton = findViewById(R.id.paymentbutton);
 
         eventId = getIntent().getIntExtra("eventID", 0);
 
+        initEventTextViews();
+
+        // get ticket type information from API
         Thread thread = new Thread(){
-          public void run(){
-              ticketTypes = eventsController.getTicketTypesByEventId(eventId);
-          }
+            public void run(){
+                ticketTypes = eventsController.getTicketTypesByEventId(eventId);
+            }
         };
         thread.start();
         try {
+            // TODO: insert something to visualize that the system is loading if necessary
             thread.join();
         } catch (InterruptedException e) {
             e.printStackTrace();
@@ -57,51 +59,84 @@ public class BuyTicketActivity extends BaseActivity {
         // TODO: remove this (only for testing purposes)
         ticketTypes.add(new TicketType(42,4.2,"Test Ticket"));
 
-        fillTicketTypeInformation(ticketTypes);
+        ticketTypeSpinner = findViewById(R.id.ticket_type_spinner);
+        ticketTypeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String ticketTypeName = (String)parent.getItemAtPosition(position);
+                setTicketTypeInformation(ticketTypeName);
+            }
 
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                // TODO: what to do here?
+            }
+        });
+
+        initializeTicketTypeSpinner();
+
+        // TODO: check if this is necessary; OnItemSelected already called initially
+        setTicketTypeInformation((String)ticketTypeSpinner.getSelectedItem());
+
+        Button paymentButton = findViewById(R.id.paymentbutton);
         paymentButton.setOnClickListener(v -> {
-            //TODO: jump to next activity, the activity to pay by Strip
+            // Jump to the payment activity
             Intent intent = new Intent(getApplicationContext(), TicketPaymentSelectActivity.class);
+            intent.putExtra("ticketTypeId", getTicketTypeForName(
+                    (String)ticketTypeSpinner.getSelectedItem()).getId());
+            intent.putExtra("eventId", eventId);
             startActivity(intent);
         });
     }
 
-    private void fillTicketTypeInformation(List<TicketType> ticketTypes){
+    private void initEventTextViews() {
         TextView eventView = findViewById(R.id.ticket_details_event);
         TextView locationView = findViewById(R.id.ticket_details_location);
         TextView dateView = findViewById(R.id.ticket_details_date);
-        TextView priceView = findViewById(R.id.ticket_details_price);
-        TextView ticketTypeView = findViewById(R.id.ticket_details_ticket_type);
 
         Event event = eventsController.getEventById(eventId);
-
-        ArrayList<String> ticketTypeNames = new ArrayList<>();
-        for (TicketType ticketType : ticketTypes){
-            ticketTypeNames.add(ticketType.getDescription());
-        }
-
-        TicketType chosenTicketType = ticketTypes.get(0);
-
-        Spinner ticketTypeSpinner = findViewById(R.id.ticket_type_spinner);
-
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(this,
-                android.R.layout.simple_spinner_item, ticketTypeNames);
-        ticketTypeSpinner.setAdapter(adapter);
 
         String eventString = event.getTitle();
         String locationString = event.getLocality();
         String dateString = new SimpleDateFormat("yyyy-MM-dd hh:mm", Locale.GERMANY).
                 format(event.getDate());
-        String priceString = new DecimalFormat("#.00").format(chosenTicketType.getPrice())
-                + " €";
-        String ticketTypeString = chosenTicketType.getDescription();
-
         eventView.append(eventString);
         locationView.append(locationString);
         dateView.append(dateString);
-        priceView.append(priceString);
-        ticketTypeView.append(ticketTypeString);
+    }
 
+    private void initializeTicketTypeSpinner() {
+        ArrayList<String> ticketTypeNames = new ArrayList<>();
+        for (TicketType ticketType : ticketTypes){
+            ticketTypeNames.add(ticketType.getDescription());
+        }
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this,
+                android.R.layout.simple_spinner_item, ticketTypeNames);
+        ticketTypeSpinner.setAdapter(adapter);
+    }
+
+    private TicketType getTicketTypeForName(String ticketTypeName){
+        for(TicketType ticketType : ticketTypes){
+            if (ticketType.getDescription().equals(ticketTypeName)){
+                return ticketType;
+            }
+        }
+        return null;
+    }
+
+    private void setTicketTypeInformation(String ticketTypeName){
+        TicketType ticketType = getTicketTypeForName(ticketTypeName);
+
+        TextView priceView = findViewById(R.id.ticket_details_price);
+        TextView ticketTypeView = findViewById(R.id.ticket_details_ticket_type);
+
+        String priceString = new DecimalFormat("#.00").format(ticketType.getPrice())
+                + " €";
+        String ticketTypeString = ticketType.getDescription();
+
+        priceView.setText(priceString);
+        ticketTypeView.setText(ticketTypeString);
     }
 
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDetailsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDetailsFragment.java
@@ -123,7 +123,8 @@ public class EventDetailsFragment extends Fragment {
         View error = headerView.findViewById(R.id.kino_cover_error);
 
         // onClickListeners
-        link.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url))));
+        link.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW,
+                Uri.parse(url))));
         // Export current activity to google calendar
         exportCalendar.setOnClickListener(view -> addToCalendar());
         // Setup "Buy/Show ticket" button according to ticket status for current event

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -123,6 +123,12 @@ public class EventsController {
         return ticketTypeDao.getById(id);
     }
 
+    /**
+     * This is not a database access but a API call
+     * Thus, it needs to be called in a thread
+     * @param eventId
+     * @return
+     */
     public List<TicketType> getTicketTypesByEventId(int eventId) {
         List<TicketType> ticketTypes = null;
         try {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -122,5 +122,15 @@ public class EventsController {
     public TicketType getTicketTypeById(int id) {
         return ticketTypeDao.getById(id);
     }
+
+    public List<TicketType> getTicketTypesByEventId(int eventId) {
+        try {
+            TUMCabeClient api = TUMCabeClient.getInstance(context);
+            return api.getTicketTypes(eventId);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -124,13 +124,14 @@ public class EventsController {
     }
 
     public List<TicketType> getTicketTypesByEventId(int eventId) {
+        List<TicketType> ticketTypes = null;
         try {
             TUMCabeClient api = TUMCabeClient.getInstance(context);
-            return api.getTicketTypes(eventId);
+            ticketTypes = api.getTicketTypes(eventId);
         } catch (IOException e) {
             e.printStackTrace();
         }
-        return null;
+        return ticketTypes;
     }
 }
 

--- a/app/src/main/res/layout/activity_buy_ticket.xml
+++ b/app/src/main/res/layout/activity_buy_ticket.xml
@@ -29,9 +29,22 @@
                     android:layout_width="fill_parent"
                     android:layout_height="fill_parent" />
 
-                <Spinner android:id="@+id/ticket_type_spinner"
+                <TextView
+                    android:id="@+id/ticket_details_choose_type_view"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"/>
+                    android:layout_height="0dp"
+                    android:layout_margin="16dp"
+                    android:layout_weight="0.3"
+                    android:text="@string/choose_ticket_type"
+                    android:textSize="@dimen/large_text_size"
+                    android:textStyle="bold" />
+
+                <Spinner
+                    android:id="@+id/ticket_type_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:prompt="@string/events"
+                    android:layout_margin="16dp"/>
 
                 <TextView
                     style="@style/SmallListSeparatorTextViewStyle"
@@ -138,29 +151,6 @@
                         android:layout_weight="0.7"
                         android:layout_height="wrap_content"
                         android:textSize="@dimen/large_text_size" />
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="10pt"
-                        android:orientation="horizontal">
-
-                        <TextView
-                            android:id="@+id/ticket_details_ticket_type_title"
-                            android:layout_width="0pt"
-                            android:layout_weight="0.3"
-                            android:layout_height="wrap_content"
-                            android:text="@string/ticket_type"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/large_text_size" />
-
-                        <TextView
-                            android:id="@+id/ticket_details_ticket_type"
-                            android:layout_width="0pt"
-                            android:layout_weight="0.7"
-                            android:layout_height="wrap_content"
-                            android:textSize="@dimen/large_text_size" />
                     </LinearLayout>
 
 

--- a/app/src/main/res/layout/activity_buy_ticket.xml
+++ b/app/src/main/res/layout/activity_buy_ticket.xml
@@ -44,6 +44,10 @@
                     android:padding="12dp"
                     android:transitionName="@string/transition_card">
 
+                    <Spinner android:id="@+id/ticket_type_spinner"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"/>
+
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_buy_ticket.xml
+++ b/app/src/main/res/layout/activity_buy_ticket.xml
@@ -29,6 +29,10 @@
                     android:layout_width="fill_parent"
                     android:layout_height="fill_parent" />
 
+                <Spinner android:id="@+id/ticket_type_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+
                 <TextView
                     style="@style/SmallListSeparatorTextViewStyle"
                     android:layout_width="wrap_content"
@@ -43,10 +47,6 @@
                     android:orientation="vertical"
                     android:padding="12dp"
                     android:transitionName="@string/transition_card">
-
-                    <Spinner android:id="@+id/ticket_type_spinner"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"/>
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -506,6 +506,7 @@ Signatur: %5$s</string>
     <string name="ticket_type">Tickettyp</string>
     <string name="price">Preis</string>
     <string name="location">Ort</string>
+    <string name="choose_ticket_type">Wähle deinen Ticket-Typ</string>
 
     <!-- Payment -->
     <string name="creditcard">Kreditkarte</string>
@@ -598,4 +599,5 @@ Signatur: %5$s</string>
     <string name="discard_changes_question">Änderungen verwerfen?</string>
     <string name="discard">Verwerfen</string>
     <string name="keep_editing">Weiter bearbeiten</string>
+    <string name="no_network_connection">Keine Verbindung zum Server möglich</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -631,5 +631,7 @@ Signature: %5$s</string>
     <string name="purchase_success_continue">Continue</string>
     <string name="card_data_invalid">The card data is invalid.</string>
     <string name="redeemed">Redeemed</string>
+    <string name="no_network_connection">Currently no connection to server possible</string>
+    <string name="choose_ticket_type">Choose your ticket type</string>
 
 </resources>


### PR DESCRIPTION
I integrated a dropdown menu to select a ticket type for an event in the BuyTicketActivity.
@schulzalexander and I discussed how we should implement the access to the ticket type data. The current model classes allow no connection between event and ticket type. However, a API call getTicketTypesForEventID exists.

The two options would have been:

1. Get all ticket types at startup and change the model classes to allow retrieving a ticket type for a certain event.
2. Get the ticket types for a certain event from the server when needed. 

We chose the second option as we figured it is easier to implement.

I am open to suggestions on how to improve the UI:

![screenshot_20180629-003027](https://user-images.githubusercontent.com/12066533/42063804-bac6abbc-7b33-11e8-8393-cdeef9f5f7ec.png)
