### PR TITLE
Added color (accent) attribute to all notification creation

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/NotificationsProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/NotificationsProvider.kt
@@ -2,6 +2,8 @@ package de.tum.`in`.tumcampusapp.component.notifications
 
 import android.content.Context
 import android.support.v4.app.NotificationCompat
+import android.support.v4.content.ContextCompat
+import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.notifications.model.AppNotification
 
 /**
@@ -14,6 +16,8 @@ import de.tum.`in`.tumcampusapp.component.notifications.model.AppNotification
  * @param context The current [Context]
  */
 abstract class NotificationsProvider(protected val context: Context) {
+
+    val notificationColorAccent = ContextCompat.getColor(context, R.color.color_primary)
 
     /**
      * Returns the [NotificationCompat.Builder] with attributes shared by all of the provider's

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/general/Update.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/general/Update.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 
 import com.google.gson.Gson;
 
@@ -90,6 +91,7 @@ public class Update extends GenericNotification {
                 .setLights(0xff0000ff, 500, 500)
                 .setSound(sound)
                 .setAutoCancel(true)
+                .setColor(ContextCompat.getColor(context, R.color.color_primary))
                 .build();
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarNotificationsProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarNotificationsProvider.kt
@@ -21,6 +21,7 @@ class CalendarNotificationsProvider(context: Context,
                 .setAutoCancel(true)
                 .setSmallIcon(R.drawable.ic_calendar)
                 .setShowWhen(false)
+                .setColor(notificationColorAccent)
     }
 
     override fun getNotifications(): List<AppNotification> {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesNotificationsProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesNotificationsProvider.kt
@@ -20,6 +20,7 @@ class TuitionFeesNotificationsProvider(
         return NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_DEFAULT)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setShowWhen(false)
+                .setColor(notificationColorAccent)
     }
 
     override fun getNotifications(): List<AppNotification> {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/alarm/AlarmNotification.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/alarm/AlarmNotification.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.Base64;
 
 import com.google.common.base.Charsets;
@@ -23,6 +24,7 @@ import java.security.spec.X509EncodedKeySpec;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.api.app.AuthenticationManager;
 import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
+import de.tum.in.tumcampusapp.component.notifications.NotificationsProvider;
 import de.tum.in.tumcampusapp.component.other.generic.GenericNotification;
 import de.tum.in.tumcampusapp.component.ui.alarm.model.GCMAlert;
 import de.tum.in.tumcampusapp.component.ui.alarm.model.GCMNotification;
@@ -158,6 +160,7 @@ public class AlarmNotification extends GenericNotification {
                 .setLights(0xff0000ff, 500, 500)
                 .setSound(sound)
                 .setAutoCancel(true)
+                .setColor(ContextCompat.getColor(context, R.color.color_primary))
                 .build();
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaNotificationsProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaNotificationsProvider.kt
@@ -29,6 +29,7 @@ class CafeteriaNotificationsProvider(
                 .setGroup(GROUP_KEY_CAFETERIA)
                 .setGroupSummary(true)
                 .setShowWhen(false)
+                .setColor(notificationColorAccent)
     }
 
     private fun getSecondaryNotificationBuilder(): NotificationCompat.Builder {
@@ -37,6 +38,7 @@ class CafeteriaNotificationsProvider(
                 .setSmallIcon(R.drawable.ic_cutlery)
                 .setGroup(GROUP_KEY_CAFETERIA)
                 .setShowWhen(false)
+                .setColor(notificationColorAccent)
     }
 
     override fun getNotifications(): List<AppNotification> {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatNotification.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatNotification.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.RemoteInput;
 import android.support.v4.app.TaskStackBuilder;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 
 import com.google.common.collect.Lists;
@@ -199,6 +200,7 @@ public class ChatNotification extends GenericNotification implements ChatMessage
                     .setLights(0xff0000ff, 500, 500)
                     .setSound(sound)
                     .setAutoCancel(true)
+                    .setColor(ContextCompat.getColor(context, R.color.color_primary))
                     .build();
 
             NotificationManager mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsNotificationsProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsNotificationsProvider.kt
@@ -22,6 +22,7 @@ class NewsNotificationsProvider(context: Context,
                 .setSmallIcon(R.drawable.ic_notification)
                 .setGroupSummary(true)
                 .setGroup(GROUP_KEY_NEWS)
+                .setColor(notificationColorAccent)
     }
 
     private fun getSecondaryNotificationBuilder(): NotificationCompat.Builder {
@@ -30,6 +31,7 @@ class NewsNotificationsProvider(context: Context,
                 .setSmallIcon(R.drawable.ic_notification)
                 .setGroup(GROUP_KEY_NEWS)
                 .setShowWhen(false)
+                .setColor(notificationColorAccent)
     }
 
     override fun getNotifications(): List<AppNotification> {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportNotificationsProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportNotificationsProvider.kt
@@ -17,6 +17,7 @@ class TransportNotificationsProvider(
     override fun getNotificationBuilder(): NotificationCompat.Builder {
         return NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_MVV)
                 .setSmallIcon(R.drawable.ic_notification)
+                .setColor(notificationColorAccent)
     }
 
     override fun getNotifications(): List<AppNotification> {

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/FavoriteDishAlarmScheduler.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/FavoriteDishAlarmScheduler.kt
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.support.v4.app.NotificationCompat
+import android.support.v4.content.ContextCompat
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.CafeteriaNotificationSettings
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.activity.CafeteriaActivity
@@ -113,6 +114,7 @@ class FavoriteDishAlarmScheduler : BroadcastReceiver() {
                     .setContentIntent(pendingIntent)
                     .setDefaults(Notification.DEFAULT_SOUND)
                     .setAutoCancel(true)
+                    .setColor(ContextCompat.getColor(context, R.color.color_primary))
                     .build()
             notificationManager.notify(IDENTIFIER_STRING, mensaId, notification)
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
@@ -174,6 +174,7 @@ class ScanResultsAvailableReceiver : BroadcastReceiver() {
                     .addAction(R.drawable.ic_notification_wifi, context.getString(R.string.setup), setupPendingIntent)
                     .setContentIntent(setupPendingIntent)
                     .setAutoCancel(true)
+                    .setColor(ContextCompat.getColor(context, R.color.color_primary))
                     .build()
 
             // Create GCMNotification Manager


### PR DESCRIPTION
## Issue

Adds a blue (logo & app name) color accent to all notifications using the .setColor() method.

## Screenshot
![tca-notification-screenshot](https://user-images.githubusercontent.com/32497625/42111658-6f6fcb64-7be5-11e8-9dc7-ae4368336953.jpg)

## Why this is useful for all students

Notifications don't look so stale and gray anymore.

