### PR TITLE
adjusted event details layout to fit 16:9 image

### DIFF
--- a/app/src/main/res/layout/event_footer.xml
+++ b/app/src/main/res/layout/event_footer.xml
@@ -62,6 +62,7 @@
         android:id="@+id/event_description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="16dp"
         android:textSize="20sp"
         tools:text="description" />
 

--- a/app/src/main/res/layout/event_header.xml
+++ b/app/src/main/res/layout/event_header.xml
@@ -1,52 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/AppTheme.GreyBackground"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <RelativeLayout
+    <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="390dp">
+        android:layout_height="wrap_content">
+
+        <RelativeLayout
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,16:9"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/kino_cover"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:contentDescription="@string/kino_cover_description"
+                android:scaleType="centerCrop" />
+
+            <ProgressBar
+                android:id="@+id/kino_cover_progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true" />
+
+            <ImageView
+                android:id="@+id/kino_cover_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:src="@drawable/error"
+                android:visibility="gone" />
 
 
-        <ImageView
-            android:id="@+id/kino_cover"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:contentDescription="@string/kino_cover_description"
-            android:scaleType="centerCrop" />
+        </RelativeLayout>
 
-        <ProgressBar
-            android:id="@+id/kino_cover_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true" />
+    </android.support.constraint.ConstraintLayout>
 
-        <ImageView
-            android:id="@+id/kino_cover_error"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:src="@drawable/error"
-            android:visibility="gone" />
-
-        <Button
-            android:id="@+id/button_ticket"
-            style="@style/KinoHeaderButton"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="17dp"
-            android:background="@drawable/buttonshape_ticket"
-            android:backgroundTint="@color/tum_500"
-            android:textColor="@color/white"
-            android:textSize="22sp"
-            android:textStyle="bold" />
-
-
-    </RelativeLayout>
+    <Button
+        android:id="@+id/button_ticket"
+        style="@style/KinoHeaderButton"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:background="@drawable/buttonshape_ticket"
+        android:backgroundTint="@color/tum_500"
+        android:textColor="@color/white"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        tools:layout_editor_absoluteX="142dp"
+        tools:layout_editor_absoluteY="140dp" />
 
 
 </LinearLayout>
+
+


### PR DESCRIPTION
The new event details layout did not fit the planned image layout of 16:9 landscape.
This Pull Requests suggests a new layout.

![screenshot_20180702-134038](https://user-images.githubusercontent.com/12066533/42162088-c086d6f4-7dfd-11e8-90aa-450118b43a59.png)


