### PR TITLE
Fix crash in BackgroundService

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/service/BackgroundService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/BackgroundService.kt
@@ -31,7 +31,11 @@ class BackgroundService : JobIntentService() {
             putExtra(Const.APP_LAUNCHES, appLaunches)
         }
         DownloadService.enqueueWork(baseContext, service)
-        Looper.prepare()
+
+        if (Looper.myLooper() == null) {
+            Looper.prepare()
+        }
+
         WifiScanHandler.getInstance().startRepetition(this)
     }
 


### PR DESCRIPTION
In 1.6.1.-beta3, the `BackgroundService` crashes because we’re attempting to create a second Looper for the current thread. This commit fixes this crash by first checking whether a Looper already exists for the current thread.