### PR TITLE
Add network resiliency testing interceptor and improve error handling

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/ChaosMonkeyInterceptor.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/ChaosMonkeyInterceptor.kt
@@ -1,0 +1,32 @@
+package de.tum.`in`.tumcampusapp.api.app
+
+import de.tum.`in`.tumcampusapp.BuildConfig
+import de.tum.`in`.tumcampusapp.api.app.exception.ChaosMonkeyException
+import de.tum.`in`.tumcampusapp.utils.Utils
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import java.util.concurrent.ThreadLocalRandom
+
+/**
+ * This is a OkHttp Interceptor designed to remind developers, that network requests can and *will*
+ * spontaneously fail.
+ * If this Interceptor is in the stacktrace your're looking at, you probably didn't gracefully
+ * handle failing network conditions
+ */
+class ChaosMonkeyInterceptor : Interceptor {
+
+    private val failProbability = 0.1
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (!BuildConfig.DEBUG) {
+            return chain.proceed(chain.request())
+        }
+        if (ThreadLocalRandom.current().nextDouble() < failProbability) {
+            Utils.log("Chaos Monkey is resilience testing your network code")
+            throw ChaosMonkeyException()
+        }
+        return chain.proceed(chain.request())
+    }
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/ChaosMonkeyInterceptor.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/ChaosMonkeyInterceptor.kt
@@ -1,6 +1,5 @@
 package de.tum.`in`.tumcampusapp.api.app
 
-import de.tum.`in`.tumcampusapp.BuildConfig
 import de.tum.`in`.tumcampusapp.api.app.exception.ChaosMonkeyException
 import de.tum.`in`.tumcampusapp.utils.Utils
 import okhttp3.Interceptor
@@ -11,7 +10,7 @@ import java.util.concurrent.ThreadLocalRandom
 /**
  * This is a OkHttp Interceptor designed to remind developers, that network requests can and *will*
  * spontaneously fail.
- * If this Interceptor is in the stacktrace your're looking at, you probably didn't gracefully
+ * If this Interceptor is in the stacktrace you're looking at, you probably didn't gracefully
  * handle failing network conditions
  */
 class ChaosMonkeyInterceptor : Interceptor {
@@ -20,9 +19,6 @@ class ChaosMonkeyInterceptor : Interceptor {
 
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
-        if (!BuildConfig.DEBUG) {
-            return chain.proceed(chain.request())
-        }
         if (ThreadLocalRandom.current().nextDouble() < failProbability) {
             Utils.log("Chaos Monkey is resilience testing your network code")
             throw ChaosMonkeyException()

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/Helper.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/Helper.java
@@ -19,6 +19,7 @@ import com.journeyapps.barcodescanner.BarcodeEncoder;
 
 import java.util.concurrent.TimeUnit;
 
+import de.tum.in.tumcampusapp.BuildConfig;
 import de.tum.in.tumcampusapp.utils.Utils;
 import okhttp3.CertificatePinner;
 import okhttp3.Interceptor;
@@ -70,7 +71,9 @@ public final class Helper {
         //Add the device identifying header
         builder.addInterceptor(Helper.getDeviceInterceptor(c));
 
-        builder.addInterceptor(new ChaosMonkeyInterceptor());
+        if (!BuildConfig.DEBUG) {
+            builder.addInterceptor(new ChaosMonkeyInterceptor());
+        }
 
         builder.addInterceptor(new ConnectivityInterceptor(c));
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/Helper.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/Helper.java
@@ -70,6 +70,8 @@ public final class Helper {
         //Add the device identifying header
         builder.addInterceptor(Helper.getDeviceInterceptor(c));
 
+        builder.addInterceptor(new ChaosMonkeyInterceptor());
+
         builder.addInterceptor(new ConnectivityInterceptor(c));
 
         builder.connectTimeout(Helper.HTTP_TIMEOUT, TimeUnit.MILLISECONDS);

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/exception/ChaosMonkeyException.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/exception/ChaosMonkeyException.kt
@@ -1,0 +1,7 @@
+package de.tum.`in`.tumcampusapp.api.app.exception
+
+/**
+ * Exception for resilience testing your network error handling
+ * If this exception crashes your app, you should feel bad and implement proper error handling
+ */
+class ChaosMonkeyException : RuntimeException("Some requests might spontaneously fail")

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/exception/ChaosMonkeyException.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/exception/ChaosMonkeyException.kt
@@ -1,7 +1,9 @@
 package de.tum.`in`.tumcampusapp.api.app.exception
 
+import java.io.IOException
+
 /**
  * Exception for resilience testing your network error handling
  * If this exception crashes your app, you should feel bad and implement proper error handling
  */
-class ChaosMonkeyException : RuntimeException("Some requests might spontaneously fail")
+class ChaosMonkeyException : IOException("Some requests might spontaneously fail")

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/TUMOnlineRequest.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/TUMOnlineRequest.java
@@ -215,6 +215,7 @@ public final class TUMOnlineRequest<T> {
                   .compose(handleLifecycle())
                   .subscribeOn(Schedulers.io())
                   .observeOn(AndroidSchedulers.mainThread())
+                .onErrorReturnItem(Optional.absent())
                   .subscribe((result) -> {
                       if (result.isPresent()) {
                           Utils.logv("Received result <" + result + '>');

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ActivityForLoadingInBackground.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ActivityForLoadingInBackground.java
@@ -72,6 +72,7 @@ public abstract class ActivityForLoadingInBackground<S, T> extends ProgressActiv
                   .compose(provider.bindToLifecycle())
                   .subscribeOn(Schedulers.io())
                   .observeOn(AndroidSchedulers.mainThread())
+                .onErrorReturnItem(Optional.absent())
                   .subscribe((result) -> {
                       showLoadingEnded();
                       onLoadFinished(result.orNull());

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ActivityForSearchingInBackground.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ActivityForSearchingInBackground.java
@@ -89,6 +89,7 @@ public abstract class ActivityForSearchingInBackground<T> extends ActivityForSea
         observable.compose(provider.bindToLifecycle())
                   .subscribeOn(Schedulers.io())
                   .observeOn(AndroidSchedulers.mainThread())
+                .onErrorReturnItem(Optional.absent())
                   .subscribe(this::onSearchFinished);
     }
 


### PR DESCRIPTION
We still have some `OnErrorNotImplementedExceptions`, which only manifest in on-device tests with shaky network conditions.

In this PR I tried to implement a way to test this in debug builds and reliably reproduce shaky network conditions.
For this I was inspired by Netflix's [ChaosMonkey project](http://principlesofchaos.org/), thus the naming of the network Interceptor.

Additionally, I already added some error handling for TUMonline requests, but I still get random crashes, when deleting the cache...

Unfortunately, the logs are relatively cluttered with the network errors...
We can maybe tune down the logging of network error messages a bit, to get a better look on the actual crashes.

If you want to reliably crash the app, set `ChaosMonkeyInterceptor.failProbability = 1` :tada: 