### PR TITLE
fix event details layout and date display

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDetailsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDetailsFragment.java
@@ -21,15 +21,14 @@ import android.widget.TextView;
 import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
 
-import java.text.SimpleDateFormat;
-import java.util.Locale;
+import java.text.DateFormat;
 
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
 import de.tum.in.tumcampusapp.utils.Const;
 import io.reactivex.disposables.CompositeDisposable;
 
-import static java.text.DateFormat.getDateInstance;
+import static java.text.DateFormat.getDateTimeInstance;
 
 /**
  * Fragment for EventDetails. Manages content that gets shown on the pagerView
@@ -124,12 +123,9 @@ public class EventDetailsFragment extends Fragment {
         TextView eventDescriptionTextView = footerView.findViewById(R.id.event_description);
         TextView eventLinkTextView = footerView.findViewById(R.id.event_link);
 
-        String timeString = new SimpleDateFormat("hh:mm", Locale.GERMANY).
-                format(event.getDate());
-        //set date format to current locale setting
-        String dateString = getDateInstance().format(event.getDate());
-        String eventDateTimeString = dateString + " " + timeString;
-        eventDateTextView.setText(eventDateTimeString);
+        // set date format to display the full date, but discard the seconds part for time (SHORT)
+        DateFormat dateFormat = getDateTimeInstance(DateFormat.DEFAULT, DateFormat.SHORT);
+        eventDateTextView.setText(dateFormat.format(event.getDate()));
 
         eventDateTextView.setOnClickListener(v -> addToCalendar());
 

--- a/app/src/main/res/layout/event_footer.xml
+++ b/app/src/main/res/layout/event_footer.xml
@@ -6,35 +6,34 @@
     android:layout_marginTop="7dp"
     android:orientation="vertical">
 
-    <LinearLayout
+    <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_height="match_parent"
+        android:layout_margin="8dp">
 
-        <View
-            android:layout_width="15dp"
-            android:layout_height="match_parent" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/event_date"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/textshape_ticket"
-            android:textColor="#46525D"
-            android:textSize="18sp" />
+            <TextView
+                android:id="@+id/event_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/textshape_ticket"
+                android:textColor="#46525D"
+                android:textSize="18sp" />
 
-        <View
-            android:layout_width="37dp"
-            android:layout_height="match_parent" />
-
-        <TextView
-            android:id="@+id/event_remainingticket"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/textshape_ticket"
-            android:textColor="#46525D"
-            android:textSize="18sp" />
-    </LinearLayout>
+            <TextView
+                android:id="@+id/event_remainingticket"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:background="@drawable/textshape_ticket"
+                android:textColor="#46525D"
+                android:textSize="18sp" />
+        </LinearLayout>
+    </HorizontalScrollView>
 
     <View
         android:layout_width="match_parent"


### PR DESCRIPTION
@kordianbruck If I remember correctly, in the last meeting we discussed that the date and tickets text views in the event details should be added to a horizontal scroll view to avoid a line break.

Futhermore, I fixed the date display. Before, 14:00 or 2 pm was displayed as 02:00.
I found that the easiest way to specify a date format is using getDateTimeInstance(int dateStyle, int timeStyle);
It is Locale sensible and offers some predefined styles like DateFormat.DEFAULT or DateFormat.Short

Here are two screenshots for German and US Locale

![screenshot_20180707-132815](https://user-images.githubusercontent.com/12066533/42410438-c9dac39c-81e9-11e8-80b4-f64804c02ff8.png)
![screenshot_1530962689](https://user-images.githubusercontent.com/12066533/42410439-c9f7c94c-81e9-11e8-9555-f32035770725.png)



