### PR TITLE
As/949 remove email from stripe request

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -42,6 +42,7 @@ import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketType;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.EphimeralKey;
+import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketPurchaseStripe;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservation;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservationCancelation;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservationResponse;
@@ -106,7 +107,7 @@ public final class TUMCabeClient {
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create());
 
         Gson gson = new GsonBuilder().registerTypeAdapter(DateTime.class, new DateSerializer())
-                                     .create();
+                .create();
         builder.addConverterFactory(GsonConverterFactory.create(gson));
         builder.client(Helper.getOkHttpClient(c));
         service = builder.build()
@@ -165,7 +166,7 @@ public final class TUMCabeClient {
 
     public void addUserToChat(ChatRoom chatRoom, ChatMember member, ChatVerification verification, Callback<ChatRoom> cb) {
         service.addUserToChat(chatRoom.getId(), member.getId(), verification)
-               .enqueue(cb);
+                .enqueue(cb);
     }
 
     public Observable<ChatMessage> sendMessage(int roomId, ChatMessage chatMessage) {
@@ -321,12 +322,12 @@ public final class TUMCabeClient {
 
     public void searchChatMember(String query, Callback<List<ChatMember>> callback) {
         service.searchMemberByName(query)
-               .enqueue(callback);
+                .enqueue(callback);
     }
 
     public void getChatMemberByLrzId(String lrzId, Callback<ChatMember> callback) {
         service.getMember(lrzId)
-               .enqueue(callback);
+                .enqueue(callback);
     }
 
     public Observable<List<Cafeteria>> getCafeterias() {
@@ -339,14 +340,14 @@ public final class TUMCabeClient {
 
     public List<News> getNews(String lastNewsId) throws IOException {
         return service.getNews(lastNewsId)
-                      .execute()
-                      .body();
+                .execute()
+                .body();
     }
 
     public List<NewsSources> getNewsSources() throws IOException {
         return service.getNewsSources()
-                      .execute()
-                      .body();
+                .execute()
+                .body();
     }
 
     public Observable<NewsAlert> getNewsAlert() {
@@ -393,13 +394,9 @@ public final class TUMCabeClient {
 
     // Ticket purchase
     public void purchaseTicketStripe(Context context, int ticketHistory, String token,
-                                       String customerName, Callback<Ticket> cb) throws IOException {
-        HashMap<String, Object> argsMap = new HashMap<>();
-        argsMap.put("ticket_history", ticketHistory);
-        argsMap.put("token", token);
-        argsMap.put("customer_name", customerName);
-
-        ChatVerification chatVerification = ChatVerification.Companion.createChatVerification(context, argsMap);
+                                     String customerName, Callback<Ticket> cb) throws IOException {
+        ChatVerification chatVerification = ChatVerification.Companion.createChatVerification(context,
+                new TicketPurchaseStripe(ticketHistory, token, customerName));
         service.purchaseTicketStripe(chatVerification).enqueue(cb);
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -392,20 +392,19 @@ public final class TUMCabeClient {
     }
 
     // Ticket purchase
-    public void purchaseTicketStripe(Context context, int ticketHistory, String token, String customerMail,
+    public void purchaseTicketStripe(Context context, int ticketHistory, String token,
                                        String customerName, Callback<Ticket> cb) throws IOException {
         HashMap<String, Object> argsMap = new HashMap<>();
         argsMap.put("ticket_history", ticketHistory);
         argsMap.put("token", token);
-        argsMap.put("customer_mail", customerMail);
         argsMap.put("customer_name", customerName);
 
         ChatVerification chatVerification = ChatVerification.Companion.createChatVerification(context, argsMap);
         service.purchaseTicketStripe(chatVerification).enqueue(cb);
     }
 
-    public void retrieveEphemeralKey(Context context, String apiVersion, String customerMail, Callback<HashMap<String, Object>> cb) throws IOException {
-        ChatVerification chatVerification = ChatVerification.Companion.createChatVerification(context, new EphimeralKey(customerMail, apiVersion));
+    public void retrieveEphemeralKey(Context context, String apiVersion, Callback<HashMap<String, Object>> cb) throws IOException {
+        ChatVerification chatVerification = ChatVerification.Companion.createChatVerification(context, new EphimeralKey(apiVersion));
         service.retrieveEphemeralKey(chatVerification).enqueue(cb);
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/StripePaymentActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/StripePaymentActivity.java
@@ -152,7 +152,6 @@ public class StripePaymentActivity extends BaseActivity {
                     .getInstance(StripePaymentActivity.this)
                     .purchaseTicketStripe(StripePaymentActivity.this, ticketHistory,
                             paymentSession.getPaymentSessionData().getSelectedPaymentMethodId(),
-                            getUserMailAddress(),
                             cardholder, new Callback<Ticket>() {
                                 @Override
                                 public void onResponse(Call<Ticket> call, Response<Ticket> response) {
@@ -249,8 +248,6 @@ public class StripePaymentActivity extends BaseActivity {
 
 
     private void initCustomerSession() {
-        String customerMail = getUserMailAddress();
-
         CustomerSession.initCustomerSession(new TicketEphemeralKeyProvider(new TicketEphemeralKeyProvider.ProgressListener() {
             @Override
             public void onStringResponse(String string) {
@@ -258,7 +255,7 @@ public class StripePaymentActivity extends BaseActivity {
                     StripePaymentActivity.showError(StripePaymentActivity.this, string);
                 }
             }
-        }, getApplicationContext(), customerMail));
+        }, getApplicationContext()));
     }
 
 
@@ -294,16 +291,6 @@ public class StripePaymentActivity extends BaseActivity {
 
     private String buildCardString(@NonNull SourceCardData data) {
         return data.getBrand() + ",  " + getString(R.string.creditcard_ending_in) + "  " + data.getLast4();
-    }
-
-
-    private String getUserMailAddress() {
-        String customerMail = Utils.getSetting(StripePaymentActivity.this, Const.LRZ_ID, "");
-        if (customerMail.length() == 0) {
-            StripePaymentActivity.showError(StripePaymentActivity.this, getString(R.string.internal_error));
-            finish();
-        }
-        return customerMail + "@mytum.de";
     }
 
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/StripePaymentActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/StripePaymentActivity.java
@@ -82,7 +82,9 @@ public class StripePaymentActivity extends BaseActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        paymentSession.onDestroy();
+        if (paymentSession != null) {
+            paymentSession.onDestroy();
+        }
         try {
             //TODO: react to cancelation?
             TUMCabeClient.getInstance(getApplicationContext()).cancelTicketReservation(StripePaymentActivity.this, ticketHistory, new Callback<TicketSuccessResponse>() {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/StripePaymentActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/StripePaymentActivity.java
@@ -125,6 +125,7 @@ public class StripePaymentActivity extends BaseActivity {
                 paymentSession.presentPaymentMethodSelection();
             }
         });
+        savedCardsButton.setEnabled(false);
 
         // Insert formated string to remind users about which amount they are going to pay
         TextView priceReminder = findViewById(R.id.payment_info_price_textview);
@@ -284,6 +285,7 @@ public class StripePaymentActivity extends BaseActivity {
             @Override
             public void onPaymentSessionDataChanged(@NonNull PaymentSessionData data) {
                 buyButton.setEnabled(true);
+                savedCardsButton.setEnabled(true);
             }
 
         }, new PaymentSessionConfig.Builder()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/TicketEphemeralKeyProvider.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/TicketEphemeralKeyProvider.java
@@ -39,7 +39,7 @@ public class TicketEphemeralKeyProvider implements EphemeralKeyProvider {
     public void createEphemeralKey(@NonNull @Size(min = 4) String apiVersion,
                                    @NonNull final EphemeralKeyUpdateListener keyUpdateListener) {
         try {
-            TUMCabeClient.getInstance(mContext).retrieveEphemeralKey(mContext, "2017-06-05", new Callback<HashMap<String, Object>>() {
+            TUMCabeClient.getInstance(mContext).retrieveEphemeralKey(mContext, apiVersion, new Callback<HashMap<String, Object>>() {
                 @Override
                 public void onResponse(Call<HashMap<String, Object>> call, Response<HashMap<String, Object>> response) {
                     String id = response.body().toString();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/TicketEphemeralKeyProvider.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/TicketEphemeralKeyProvider.java
@@ -28,20 +28,18 @@ public class TicketEphemeralKeyProvider implements EphemeralKeyProvider {
 
     private @NonNull ProgressListener mProgressListener;
     private Context mContext;
-    private String mCustomerMail;
 
     public TicketEphemeralKeyProvider(@NonNull ProgressListener progressListener,
-                                      Context context, String customerMail) {
+                                      Context context) {
         mProgressListener = progressListener;
         mContext = context;
-        mCustomerMail = customerMail;
     }
 
     @Override
     public void createEphemeralKey(@NonNull @Size(min = 4) String apiVersion,
                                    @NonNull final EphemeralKeyUpdateListener keyUpdateListener) {
         try {
-            TUMCabeClient.getInstance(mContext).retrieveEphemeralKey(mContext, "2017-06-05", mCustomerMail, new Callback<HashMap<String, Object>>() {
+            TUMCabeClient.getInstance(mContext).retrieveEphemeralKey(mContext, "2017-06-05", new Callback<HashMap<String, Object>>() {
                 @Override
                 public void onResponse(Call<HashMap<String, Object>> call, Response<HashMap<String, Object>> response) {
                     String id = response.body().toString();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/payload/EphimeralKey.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/payload/EphimeralKey.kt
@@ -3,7 +3,5 @@ package de.tum.`in`.tumcampusapp.component.ui.ticket.payload
 import com.google.gson.annotations.SerializedName
 
 
-data class EphimeralKey(@SerializedName("customer_mail")
-                        var customerMail: String = "",
-                        @SerializedName("api_version")
+data class EphimeralKey(@SerializedName("api_version")
                         var apiVersion: String = "")

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/payload/TicketPurchaseStripe.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/payload/TicketPurchaseStripe.kt
@@ -1,0 +1,10 @@
+package de.tum.`in`.tumcampusapp.component.ui.ticket.payload
+
+import com.google.gson.annotations.SerializedName
+
+
+data class TicketPurchaseStripe(@SerializedName("ticket_history")
+                                var ticketHistory: Int = 0,
+                                var token: String = "",
+                                @SerializedName("customer_name")
+                                var customerName: String = "")


### PR DESCRIPTION
For the purchase and communication with Stripe, we need the user's email (lrz_id + "@mytum.de").
Before, we were giving this as a post parameter from the client to our backend on request, which is bad^^
We changed it so that the email is generated on the server (we have the lrz_id there after successfull authentication).

Therefore, I removed the parts from the Stripe checkout and the TumCabeClient that generated and used the mail address on the client side.