### PR TITLE
Fix link in TuitionFeesActivity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesActivity.java
@@ -1,6 +1,8 @@
 package de.tum.in.tumcampusapp.component.tumui.tutionfees;
 
 import android.os.Bundle;
+import android.text.Html;
+import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.widget.TextView;
 
@@ -35,7 +37,12 @@ public class TuitionFeesActivity extends ActivityForAccessingTumOnline<TuitionLi
         amountTextView = findViewById(R.id.soll);
         deadlineTextView = findViewById(R.id.deadline);
         semesterTextView = findViewById(R.id.semester);
-        ((TextView) findViewById(R.id.fees_aid)).setMovementMethod(LinkMovementMethod.getInstance());
+
+        // Set the text in the information box and make the link clickable
+        TextView informationTextView = findViewById(R.id.fees_aid);
+        Spanned information = Html.fromHtml(getString(R.string.tuition_fee_more));
+        informationTextView.setText(information);
+        informationTextView.setMovementMethod(LinkMovementMethod.getInstance());
 
         requestFetch();
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -326,7 +326,7 @@
     <string name="error_setup_chat_member">Etwas stimmt nicht mit deiner Chat Registrierung!</string>
     <string name="room_timetable">Belegungsplan</string>
     <string name="newspread_summary">Wähle aus welches newspread angezeigt werden soll. Das sind die Folien die auf den Info Monitoren in deiner Fakultät angezeigt werden.</string>
-    <string name="tuition_fee_more">Informationen zu Beiträgen und Befreiungen, Darlehen, BAföG oder Stipendien finden Sie unter: <a href="https://www.tum.de/studium/studienfinanzierung/">Studienfinanzierung</a></string>
+    <string name="tuition_fee_more">Informationen zu Beiträgen und Befreiungen, Darlehen, BAföG oder Stipendien finden Sie unter <![CDATA[<a<a href="https://www.tum.de/studium/studienfinanzierung/">Studienfinanzierung</a>]]>.</string>
     <string name="no_rights_to_access_id">Identität konnte nicht abgefragt werden. Bitte überprüfe die Rechte deines TUMonline Tokens!</string>
     <string name="vibration">Vibration</string>
     <string name="silent">Leise</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -326,7 +326,7 @@
     <string name="error_setup_chat_member">Etwas stimmt nicht mit deiner Chat Registrierung!</string>
     <string name="room_timetable">Belegungsplan</string>
     <string name="newspread_summary">Wähle aus welches newspread angezeigt werden soll. Das sind die Folien die auf den Info Monitoren in deiner Fakultät angezeigt werden.</string>
-    <string name="tuition_fee_more">Informationen zu Beiträgen und Befreiungen, Darlehen, BAföG oder Stipendien finden Sie unter <![CDATA[<a<a href="https://www.tum.de/studium/studienfinanzierung/">Studienfinanzierung</a>]]>.</string>
+    <string name="tuition_fee_more">Informationen zu Beiträgen und Befreiungen, Darlehen, BAföG oder Stipendien finden Sie unter <![CDATA[<a href="https://www.tum.de/studium/studienfinanzierung/">Studienfinanzierung</a>]]>.</string>
     <string name="no_rights_to_access_id">Identität konnte nicht abgefragt werden. Bitte überprüfe die Rechte deines TUMonline Tokens!</string>
     <string name="vibration">Vibration</string>
     <string name="silent">Leise</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,7 +354,7 @@
     <string name="room_timetable">Room timetable</string>
     <string name="newspread" translatable="false" translateable="false">Newspread</string>
     <string name="newspread_summary">Select which newspread you want to be shown. This are the slides on the info monitors in your faculty buildings.</string>
-    <string name="tuition_fee_more">For information on contributions and exemptions, loans, training assistance and scholarships visit <a href="https://www.tum.de/en/studies/fees-and-financial-aid/">Student Financial Aid</a></string>
+    <string name="tuition_fee_more">For information on contributions and exemptions, loans, training assistance and scholarships visit <![CDATA[<a href="https://www.tum.de/en/studies/fees-and-financial-aid/">Student Financial Aid</a>]]>.</string>
     <string name="no_rights_to_access_id">Identity could not be accessed. Please check the rights of your TUMonline token!</string>
     <string name="vibration">Vibration</string>
     <string name="silent">Silent</string>


### PR DESCRIPTION
Previously, the space before the actual link was also underlined. This commit fixes this by using CDATA in the string resource.