### PR TITLE
Remove maxHeight on image view to make it adapt to image aspect ratio

### DIFF
--- a/app/src/main/res/layout/card_top_news.xml
+++ b/app/src/main/res/layout/card_top_news.xml
@@ -7,7 +7,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:maxHeight="200dp"
         android:minHeight="50dp"
         android:scaleType="centerCrop"
         android:src="@drawable/mvv_entire_net_icon"/>


### PR DESCRIPTION
This commit makes sure that the TopNews image is displayed with the correct aspect ratio.