### PR TITLE
Add loading indicator to MainActivity on first load

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainActivity.java
@@ -77,6 +77,7 @@ public class MainActivity extends BaseActivity implements SwipeRefreshLayout.OnR
         // Setup pull to refresh
         mSwipeRefreshLayout = findViewById(R.id.ptr_layout);
         mSwipeRefreshLayout.setOnRefreshListener(this);
+        mSwipeRefreshLayout.setRefreshing(true);
         mSwipeRefreshLayout.setColorSchemeResources(
                 R.color.color_primary,
                 R.color.tum_A100,


### PR DESCRIPTION
This commit adds a loading indicator when `MainActivity` is started. When the updates takes a little longer, this reassures the user that it is still running.