### PR TITLE
Properly finish setup wizard

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavCheckTokenActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavCheckTokenActivity.java
@@ -101,9 +101,9 @@ public class WizNavCheckTokenActivity extends ActivityForLoadingInBackground<Voi
     @Override
     protected void onLoadFinished(Integer errorMessageStrResId) {
         if (errorMessageStrResId == null) {
-            finish();
-            startActivity(new Intent(this, WizNavExtrasActivity.class));
+            Intent intent = new Intent(this, WizNavExtrasActivity.class);
             overridePendingTransition(R.anim.fadein, R.anim.fadeout);
+            startActivity(intent);
         } else {
             Utils.showToast(this, errorMessageStrResId);
             showLoadingEnded();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
@@ -178,8 +178,12 @@ public class WizNavExtrasActivity extends ActivityForLoadingInBackground<Void, C
         }
         editor.apply();
 
-        finish();
-        startActivity(new Intent(this, StartupActivity.class));
+        // Start the StartupActivity in a new, empty Task. We finish the current Activity and remove
+        // the current Task, which it is in.
+        Intent intent = new Intent(this, StartupActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        startActivity(intent);
+        finishAndRemoveTask();
     }
 
     /**
@@ -192,16 +196,14 @@ public class WizNavExtrasActivity extends ActivityForLoadingInBackground<Void, C
         startLoading();
     }
 
-    /**
-     * If back key is pressed, open previous activity
-     */
     @Override
     public void onBackPressed() {
+        // Return back to WizNavStartActivity
         finish();
         Intent intent = new Intent(this, WizNavStartActivity.class);
         intent.putExtra(Const.TOKEN_IS_SETUP, tokenSetup);
-        startActivity(intent);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         overridePendingTransition(R.anim.fadein, R.anim.fadeout);
-
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavStartActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavStartActivity.java
@@ -44,11 +44,11 @@ public class WizNavStartActivity extends ActivityForLoadingInBackground<String, 
         disableRefresh();
         findViewById(R.id.wizard_start_layout).requestFocus();
 
-        lrzIdEditText = findViewById(R.id.lrz_id);
-        lrzIdEditText.setText(Utils.getSetting(this, Const.LRZ_ID, ""));
-        lrzIdEditText.addTextChangedListener(this);
-
         nextButton = findViewById(R.id.next_button);
+
+        lrzIdEditText = findViewById(R.id.lrz_id);
+        lrzIdEditText.addTextChangedListener(this);
+        lrzIdEditText.setText(Utils.getSetting(this, Const.LRZ_ID, ""));
     }
 
     @Override
@@ -152,8 +152,9 @@ public class WizNavStartActivity extends ActivityForLoadingInBackground<String, 
     @Override
     protected void onLoadFinished(Boolean result) {
         if (result) {
-            startActivity(new Intent(this, WizNavCheckTokenActivity.class));
+            Intent intent = new Intent(this, WizNavCheckTokenActivity.class);
             overridePendingTransition(R.anim.fadein, R.anim.fadeout);
+            startActivity(intent);
         } else {
             showLoadingEnded();
         }


### PR DESCRIPTION
This commit fixes #935. Currently, the user can return to the setup wizard by pressing the back button in MainActivity. To avoid this, we start `StartupActivity` in a new `Task` and remove the `Task` to which the setup wizard activities belong.