### PR TITLE
Fix crash in card widget

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.java
@@ -140,10 +140,6 @@ public class NewsCard extends NotificationAwareCard {
         final String imgURL = mNews.getImage();
         if (!imgURL.trim().isEmpty() && !"null".equals(imgURL)) {
             Utils.log(imgURL);
-            Picasso.get()
-                   .load(imgURL)
-                   .into(remoteViews, R.id.widgetCardImageView, new int[]{appWidgetId});
-
             Handler uiHandler = new Handler(Looper.getMainLooper());
             uiHandler.post(() -> {
                 Picasso.get()


### PR DESCRIPTION
This bug was previously fixed, but the bug-causing code was accidentally left in the app. This commit fixes that.