### PR TITLE
Ticket Sale: pull-to-refresh to update ticket and event data from server

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -355,10 +355,8 @@ public final class TUMCabeClient {
 
     // TICKET SALE
     // Getting event information
-    public List<Event> getEvents() throws IOException {
-        List<Event> list = service.getEvents().execute().body();
-
-        return list;
+    public void getEvents(Callback<List<Event>> cb) {
+        service.getEvents().enqueue(cb);
     }
 
     public Event getEvent(int eventID) throws IOException {

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -355,7 +355,7 @@ public final class TUMCabeClient {
 
     // TICKET SALE
     // Getting event information
-    public void getEvents(Callback<List<Event>> cb) {
+    public void fetchEvents(Callback<List<Event>> cb) {
         service.getEvents().enqueue(cb);
     }
 
@@ -369,12 +369,12 @@ public final class TUMCabeClient {
     }
 
     // Getting ticket information
-    public void getTickets(Context context, Callback<List<Ticket>> cb) throws IOException {
+    public void fetchTickets(Context context, Callback<List<Ticket>> cb) throws IOException {
         ChatVerification chatVerification = ChatVerification.Companion.createChatVerification(context, null);
         service.getTickets(chatVerification).enqueue(cb);
     }
 
-    public void getTicketTypes(int eventID, Callback<List<TicketType>> cb) {
+    public void fetchTicketTypes(int eventID, Callback<List<TicketType>> cb) {
         service.getTicketTypes(eventID).enqueue(cb);
     }
 
@@ -402,7 +402,7 @@ public final class TUMCabeClient {
         service.retrieveEphemeralKey(chatVerification).enqueue(cb);
     }
 
-    public void getTicketStats(int event, Callback<List<TicketStatus>> cb) {
+    public void fetchTicketStats(int event, Callback<List<TicketStatus>> cb) {
         service.getTicketStats(event).enqueue(cb);
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -139,7 +139,12 @@ public class EventsController implements ProvidesCard{
         List<Ticket> tickets = ticketDao.getAll();
         List<Event> bookedEvents = new ArrayList<>();
         for (Ticket ticket : tickets) {
-            bookedEvents.add(getEventById(ticket.getEventId()));
+            Event event = getEventById(ticket.getEventId());
+            // the event may be null if the corresponding event of a ticket has already been deleted
+            // these event should not be returned
+            if (event != null){
+                bookedEvents.add(event);
+            }
         }
         return bookedEvents;
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -1,7 +1,6 @@
 package de.tum.in.tumcampusapp.component.ui.ticket;
 
 import android.content.Context;
-import android.support.v4.widget.SwipeRefreshLayout;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -50,7 +49,7 @@ public class EventsController implements ProvidesCard{
             public void onResponse(Call<List<Event>> call, Response<List<Event>> response) {
                 List<Event> events = response.body();
                 if (events == null) {
-                    events = new ArrayList<>();
+                    return;
                 }
                 addEvents(events);
             }
@@ -66,7 +65,7 @@ public class EventsController implements ProvidesCard{
             public void onResponse(Call<List<Ticket>> call, Response<List<Ticket>> response) {
                 List<Ticket> tickets = response.body();
                 if (tickets == null) {
-                    tickets = new ArrayList<>();
+                    return;
                 }
                 addTickets(tickets);
                 loadTicketTypesForTickets(tickets);
@@ -87,12 +86,12 @@ public class EventsController implements ProvidesCard{
         eventDao.cleanUp();
 
         // Load all events
-        TUMCabeClient.getInstance(context).getEvents(eventCallback);
+        TUMCabeClient.getInstance(context).fetchEvents(eventCallback);
 
         // Load all tickets
         try {
             if (Utils.getSetting(context, Const.CHAT_MEMBER, ChatMember.class) != null) {
-                TUMCabeClient.getInstance(context).getTickets(context, ticketCallback);
+                TUMCabeClient.getInstance(context).fetchTickets(context, ticketCallback);
             }
         } catch (IOException e) {
             Utils.log(e);
@@ -102,14 +101,14 @@ public class EventsController implements ProvidesCard{
     private void loadTicketTypesForTickets(List<Ticket> tickets){
         // get ticket type information for all tickets
         for (Ticket ticket : tickets){
-            TUMCabeClient.getInstance(context).getTicketTypes(ticket.getEventId(),
+            TUMCabeClient.getInstance(context).fetchTicketTypes(ticket.getEventId(),
                     new Callback<List<TicketType>>(){
 
                         @Override
                         public void onResponse(Call<List<TicketType>> call, Response<List<TicketType>> response) {
                             List<TicketType> ticketTypes = response.body();
                             if (ticketTypes == null) {
-                                ticketTypes = new ArrayList<>();
+                                return;
                             }
                             // add found ticket types to database (needed in ShowTicketActivity)
                             addTicketTypes(ticketTypes);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
@@ -1,7 +1,6 @@
 package de.tum.in.tumcampusapp.component.ui.ticket.activity;
 
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.ContextThemeWrapper;
@@ -55,7 +54,7 @@ public class BuyTicketActivity extends BaseActivity {
         eventId = getIntent().getIntExtra("eventID", 0);
 
         // get ticket type information from API
-        TUMCabeClient.getInstance(getApplicationContext()).getTicketTypes(eventId,
+        TUMCabeClient.getInstance(getApplicationContext()).fetchTicketTypes(eventId,
                 new Callback<List<TicketType>>() {
 
                     @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.java
@@ -178,7 +178,7 @@ public class EventDetailsFragment extends Fragment implements SwipeRefreshLayout
     }
 
     private void setAvailableTicketCount() {
-        TUMCabeClient.getInstance(context).getTicketStats(event.getId(), new retrofit2.Callback<List<TicketStatus>>() {
+        TUMCabeClient.getInstance(context).fetchTicketStats(event.getId(), new retrofit2.Callback<List<TicketStatus>>() {
             @Override
             public void onResponse(Call<List<TicketStatus>> call, Response<List<TicketStatus>> response) {
                 // stats is array of TicketStats, each containing info about one ticket type associated with the event

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventFragment.java
@@ -1,6 +1,7 @@
 package de.tum.in.tumcampusapp.component.ui.ticket.fragment;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -11,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import de.tum.in.tumcampusapp.R;
@@ -18,6 +20,11 @@ import de.tum.in.tumcampusapp.component.other.generic.adapter.EqualSpacingItemDe
 import de.tum.in.tumcampusapp.component.ui.ticket.EventsController;
 import de.tum.in.tumcampusapp.component.ui.ticket.adapter.EventsAdapter;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
+import de.tum.in.tumcampusapp.utils.Utils;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefreshListener {
     private View view;
@@ -27,13 +34,60 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
 
     private EventsController eventsController;
 
+    private Callback<List<Event>> eventCallback;
+    private Callback<List<Ticket>> ticketCallback;
+
     public EventFragment() {
+        init("No title");
     }
 
     @SuppressLint("ValidFragment")
     public EventFragment(String title) {
+        init(title);
+    }
+
+    private void init(String title){
         this.title = title;
-        eventsController = new EventsController(this.getContext());
+
+        eventCallback = new Callback<List<Event>>() {
+            @Override
+            public void onResponse(Call<List<Event>> call, Response<List<Event>> response) {
+                List<Event> events = response.body();
+                if (events == null){
+                    events = new ArrayList<>();
+                }
+                eventsController.addEvents(events);
+                loadEventsFromDatabase();
+                mSwipeLayout.setRefreshing(false);
+            }
+
+            @Override
+            public void onFailure(Call<List<Event>> call, Throwable t) {
+                Utils.log(t);
+                Utils.showToast(getContext(), R.string.no_internet_connection);
+                mSwipeLayout.setRefreshing(false);
+            }
+        };
+
+        ticketCallback = new Callback<List<Ticket>>() {
+            @Override
+            public void onResponse(Call<List<Ticket>> call, Response<List<Ticket>> response) {
+                List<Ticket> tickets = response.body();
+                if (tickets == null){
+                    tickets = new ArrayList<>();
+                }
+                eventsController.addTickets(tickets);
+                loadEventsFromDatabase();
+                mSwipeLayout.setRefreshing(false);
+            }
+
+            @Override
+            public void onFailure(Call<List<Ticket>> call, Throwable t) {
+                Utils.log(t);
+                Utils.showToast(getContext(), R.string.no_internet_connection);
+                mSwipeLayout.setRefreshing(false);
+            }
+        };
     }
 
     @Nullable
@@ -44,7 +98,15 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
         mSwipeLayout = view.findViewById(R.id.event_refresh);
         mSwipeLayout.setOnRefreshListener(this);
         return view;
+    }
 
+    @Override
+    public void onAttach(Context context){
+        super.onAttach(context);
+
+        // create the events controller here as the context is only created when the
+        // fragment is attached to an activity
+        eventsController = new EventsController(this.getContext());
     }
 
     private void setRecyclerView() {
@@ -56,13 +118,11 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
                 .setLayoutManager(new LinearLayoutManager(getActivity()));
         int spacing = Math.round(getResources().getDimension(R.dimen.material_card_view_padding));
         recyclerView.addItemDecoration(new EqualSpacingItemDecoration(spacing));
-        loadEvents();
+        loadEventsFromDatabase();
 
     }
 
-    private void loadEvents(){
-        // TODO: get events here from server?
-
+    private void loadEventsFromDatabase(){
         List<Event> events;
         if (title.equals(this.getString(R.string.booked_events))) {
             events = eventsController.getBookedEvents();
@@ -76,7 +136,6 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
 
     @Override
     public void onRefresh() {
-        loadEvents();
-        mSwipeLayout.setRefreshing(false);
+        eventsController.getEventsAndTicketsFromServer(eventCallback, ticketCallback);
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventFragment.java
@@ -54,7 +54,7 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
             public void onResponse(Call<List<Event>> call, Response<List<Event>> response) {
                 List<Event> events = response.body();
                 if (events == null){
-                    events = new ArrayList<>();
+                    return;
                 }
                 eventsController.addEvents(events);
                 loadEventsFromDatabase();
@@ -74,7 +74,7 @@ public class EventFragment extends Fragment implements SwipeRefreshLayout.OnRefr
             public void onResponse(Call<List<Ticket>> call, Response<List<Ticket>> response) {
                 List<Ticket> tickets = response.body();
                 if (tickets == null){
-                    tickets = new ArrayList<>();
+                    return;
                 }
                 eventsController.addTickets(tickets);
                 loadEventsFromDatabase();

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -119,7 +119,7 @@ class DownloadService : JobIntentService() {
     }
 
     private fun downloadEvents(force: Boolean): Boolean {
-        EventsController(this).downloadFromService(force)
+        EventsController(this).downloadFromService()
         return true
     }
 


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #991

I made the getEvents server call use a retrofit callback. This is now used in the EventFragment to update the events and tickets on pull-to-refresh

