### PR TITLE
Fix crash in MVVWidgetConfigureActivity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidgetConfigureActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidgetConfigureActivity.java
@@ -36,13 +36,14 @@ public class MVVWidgetConfigureActivity extends ActivityForSearchingInBackground
 
     public MVVWidgetConfigureActivity() {
         super(R.layout.activity_mvv_widget_configure, MVVStationSuggestionProvider.AUTHORITY, 3);
-        recentsDao = TcaDb.getInstance(this)
-                          .recentsDao();
     }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        recentsDao = TcaDb.getInstance(this)
+                .recentsDao();
 
         // Setup cancel button
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
This commit fixes a crash in `MVVWidgetConfigureActivity` which occurred when adding the MVV widget. It only occurred when the app was completely closed (removed from the Recents screen). 

**Reason**
In the constructor of `MVVWidgetConfigureActivity `, we passed `this` as the `Context` to `TcaDb.getInstance()`. There, we called `context.getApplicationContext()`, which will eventually invoke `ContextWrapper.getApplicationContext()`. There, `getApplicationContext()` is called on its property `mBase`, which is a `Context`. However, `mBase` is only set with `attachBaseContext()`. If we use `this` in the constructor, this method has not run yet.