### PR TITLE
Fix wrong end time and timezone in calendar export

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.java
@@ -102,9 +102,8 @@ public class CalendarController implements ProvidesCard {
         List<CalendarItem> calendarItems = calendarDao.getAllNotCancelled();
         for (CalendarItem calendarItem : calendarItems) {
             ContentValues values = calendarItem.toContentValues();
-
             values.put(CalendarContract.Events.CALENDAR_ID, id);
-            values.put(CalendarContract.Events.EVENT_TIMEZONE, R.string.calendarTimeZone);
+            values.put(CalendarContract.Events.EVENT_TIMEZONE, c.getString(R.string.calendarTimeZone));
             contentResolver.insert(CalendarContract.Events.CONTENT_URI, values);
         }
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
@@ -80,13 +80,11 @@ data class CalendarItem(@PrimaryKey
                 .trim { it <= ' ' }
     }
 
-
     fun getEventDateString(): String {
         val timeFormat = DateTimeFormat.forPattern("HH:mm").withLocale(Locale.US)
         val dateFormat = DateTimeFormat.forPattern("EEE, dd.MM.yyyy").withLocale(Locale.US)
         return String.format("%s %s - %s", dateFormat.print(eventStart), timeFormat.print(eventStart), timeFormat.print(eventEnd))
     }
-
 
     /**
      * Prepares ContentValues object with related values plugged
@@ -97,7 +95,7 @@ data class CalendarItem(@PrimaryKey
         // Put the received values into a contentResolver to
         // transmit the to Google Calendar
         values.put(CalendarContract.Events.DTSTART, eventStart.millis)
-        values.put(CalendarContract.Events.DTEND, eventStart.millis)
+        values.put(CalendarContract.Events.DTEND, eventEnd.millis)
         values.put(CalendarContract.Events.TITLE, title)
         values.put(CalendarContract.Events.DESCRIPTION, description)
         values.put(CalendarContract.Events.EVENT_LOCATION, location)


### PR DESCRIPTION
This commit fixes two parts of the calendar export: 
1. The resource ID of the timezone string was passed as the timezone, not the timezone itself.
2. The start time of the event was also used as the end time.