### PR TITLE
Re-enable and fix calendar sync

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
@@ -204,6 +204,9 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<Events>
                                         })
                                         .show();
                             }
+                        }, throwable -> {
+                            Utils.log(throwable);
+                            Utils.showToast(this, R.string.export_to_google_error);
                         })
         );
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/FillCacheService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/FillCacheService.kt
@@ -6,7 +6,6 @@ import android.support.v4.app.JobIntentService
 import de.tum.`in`.tumcampusapp.utils.CacheManager
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
-import org.jetbrains.anko.doAsync
 
 /**
  * Service used to fill caches in background, for faster/offline access
@@ -24,10 +23,8 @@ class FillCacheService : JobIntentService() {
     }
 
     override fun onHandleWork(intent: Intent) {
-        doAsync {
-            val cacheManager = CacheManager(this@FillCacheService)
-            cacheManager.fillCache()
-        }
+        val cacheManager = CacheManager(this@FillCacheService)
+        cacheManager.fillCache()
     }
 
     companion object {

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
@@ -4,13 +4,14 @@ import android.content.Context
 import de.tum.`in`.tumcampusapp.api.tumonline.AccessTokenManager
 import de.tum.`in`.tumcampusapp.api.tumonline.CacheControl
 import de.tum.`in`.tumcampusapp.api.tumonline.TUMOnlineClient
+import de.tum.`in`.tumcampusapp.component.tumui.calendar.CalendarController
+import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.Events
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LecturesResponse
 import de.tum.`in`.tumcampusapp.component.ui.chat.ChatRoomController
 import okhttp3.Cache
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.io.IOException
 
 class CacheManager(private val context: Context) {
 
@@ -27,14 +28,23 @@ class CacheManager(private val context: Context) {
     }
 
     fun syncCalendar() {
-        try {
-            TUMOnlineClient
-                    .getInstance(context)
-                    .getCalendar(CacheControl.USE_CACHE)
-                    .execute()
-        } catch (e: IOException) {
-            Utils.log(e, "Error while loading calendar in CacheManager")
-        }
+        TUMOnlineClient
+                .getInstance(context)
+                .getCalendar(CacheControl.USE_CACHE)
+                .enqueue(object : Callback<Events> {
+                    override fun onResponse(call: Call<Events>, response: Response<Events>) {
+                        val events = response.body() ?: return
+
+                        val calendarController = CalendarController(context)
+                        calendarController.importCalendar(events)
+
+                        CalendarController.QueryLocationsService.loadGeo(context)
+                    }
+
+                    override fun onFailure(call: Call<Events>, t: Throwable) {
+                        Utils.log(t, "Error while loading calendar in CacheManager")
+                    }
+                })
     }
 
     private fun syncPersonalLectures() {

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
@@ -34,10 +34,7 @@ class CacheManager(private val context: Context) {
                 .enqueue(object : Callback<Events> {
                     override fun onResponse(call: Call<Events>, response: Response<Events>) {
                         val events = response.body() ?: return
-
-                        val calendarController = CalendarController(context)
-                        calendarController.importCalendar(events)
-
+                        CalendarController(context).importCalendar(events)
                         CalendarController.QueryLocationsService.loadGeo(context)
                     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -569,4 +569,5 @@ Signatur: %5$s</string>
     <string name="error_request_limit_reached">Du hast das Anfragelimit für TUMonline erreicht. Versuche es später erneut.</string>
     <string name="error_access_token_limit_reached">Limit an Access-Tokens erreicht. Du musst einen Access-Token in TUMonline löschen, bevor du fortfahren kannst.</string>
     <string name="error_unknown">Unbekannter Fehler.</string>
+    <string name="export_to_google_error">Ein Fehler ist während des Kalender-Exports zu Google Kalender aufgetreten.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <!-- Calendar -->
     <string name="dialog_show_calendar">Export successful.\nShow local calendar <i>TUM_CAMPUS_APP</i> on <i>Google Calendar App</i>?</string>
     <string name="export_to_google">Export to Google</string>
+    <string name="export_to_google_error">An error occurred while exporting your calendar to Google Calendar.</string>
     <string name="calendarTimeZone" translatable="false">Germany/Munich</string>
     <string name="delete_from_google">Delete from Google</string>
     <string name="dialog_delete_calendar">Do you want to delete  the <i>TUM_CAMPUS_APP</i>  calendar from your device?</string>


### PR DESCRIPTION
In #940, I accidentally omitted the calendar sync. This commit re-enables it and also prevents a sync-related crash that occurred exclusively on Huawei devices. (see commit messages for more info)