### PR TITLE
Refactor parts of CafeteriaLocalRepository to prevent widget crash

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaDao.java
@@ -16,7 +16,7 @@ public interface CafeteriaDao {
     Flowable<List<Cafeteria>> getAll();
 
     @Query("SELECT * FROM cafeteria WHERE id = :id")
-    Flowable<Cafeteria> getById(int id);
+    Cafeteria getById(int id);
 
     @Query("DELETE FROM cafeteria")
     void removeCache();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuDao.java
@@ -27,10 +27,10 @@ public interface CafeteriaMenuDao {
     Flowable<List<String>> getNextDatesForDish(int cafeteriaId, String dishName);
 
     @Query("SELECT DISTINCT date FROM cafeteriaMenu WHERE date >= date('now','localtime') ORDER BY date")
-    Flowable<List<DateTime>> getAllDates();
+    List<DateTime> getAllDates();
 
     @Query("SELECT id, cafeteriaId, date, typeShort, typeLong, 0 AS typeNr, group_concat(name, '\n') AS name FROM cafeteriaMenu " +
-           "WHERE cafeteriaId = :cafeteriaId AND date = :date " +
-           "GROUP BY typeLong ORDER BY typeShort=\"tg\" DESC, typeShort ASC, typeNr")
-    Flowable<List<CafeteriaMenu>> getTypeNameFromDbCard(int cafeteriaId, DateTime date);
+            "WHERE cafeteriaId = :cafeteriaId AND date = :date " +
+            "GROUP BY typeLong ORDER BY typeShort=\"tg\" DESC, typeShort ASC, typeNr")
+    List<CafeteriaMenu> getTypeNameFromDbCard(int cafeteriaId, DateTime date);
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
@@ -34,29 +34,31 @@ class CafeteriaViewModel(private val localRepository: CafeteriaLocalRepository,
 
     fun getCafeteriaWithMenus(cafeteriaId: Int): CafeteriaWithMenus {
         return CafeteriaWithMenus(cafeteriaId).apply {
-            name = getCafeteriaNameFromId(id).blockingFirst()
+            name = getCafeteriaNameFromId(id)
             menuDates = getAllMenuDates().blockingFirst()
             menus = getCafeteriaMenus(id, nextMenuDate).blockingFirst()
         }
     }
 
-    fun getCafeteriaNameFromId(id: Int): Flowable<String> =
-            localRepository.getCafeteria(id)
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .map { it.name }
+    private fun getCafeteriaNameFromId(id: Int): String {
+        return localRepository.getCafeteria(id).name
+    }
 
-    fun getCafeteriaMenus(id: Int, date: DateTime): Flowable<List<CafeteriaMenu>> =
-            localRepository.getCafeteriaMenus(id,date)
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .defaultIfEmpty(emptyList())
+    fun getCafeteriaMenus(id: Int, date: DateTime): Flowable<List<CafeteriaMenu>> {
+        return Flowable
+                .fromCallable { localRepository.getCafeteriaMenus(id, date) }
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .defaultIfEmpty(emptyList())
+    }
 
-    fun getAllMenuDates(): Flowable<List<DateTime>> =
-            localRepository.getAllMenuDates()
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .defaultIfEmpty(emptyList())
+    fun getAllMenuDates(): Flowable<List<DateTime>> {
+        return Flowable
+                .fromCallable { localRepository.getAllMenuDates() }
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .defaultIfEmpty(emptyList())
+    }
 
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaLocalRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaLocalRepository.kt
@@ -21,17 +21,18 @@ object CafeteriaLocalRepository {
 
     // Menu methods //
 
-    fun getCafeteriaMenus(id: Int, date: DateTime): Flowable<List<CafeteriaMenu>> =
-            db.cafeteriaMenuDao().getTypeNameFromDbCard(id, date)
+    fun getCafeteriaMenus(id: Int, date: DateTime): List<CafeteriaMenu> {
+        return db.cafeteriaMenuDao().getTypeNameFromDbCard(id, date)
+    }
 
-    fun getAllMenuDates(): Flowable<List<DateTime>> = db.cafeteriaMenuDao().allDates
+    fun getAllMenuDates(): List<DateTime> = db.cafeteriaMenuDao().allDates
 
 
     // Canteen methods //
 
     fun getAllCafeterias(): Flowable<List<Cafeteria>> = db.cafeteriaDao().all
 
-    fun getCafeteria(id: Int): Flowable<Cafeteria> = db.cafeteriaDao().getById(id)
+    fun getCafeteria(id: Int): Cafeteria = db.cafeteriaDao().getById(id)
 
     fun addCafeteria(cafeteria: Cafeteria) = executor.execute { db.cafeteriaDao().insert(cafeteria) }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaRemoteViewFactory.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaRemoteViewFactory.java
@@ -6,7 +6,6 @@ import android.widget.RemoteViewsService;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 import de.tum.in.tumcampusapp.R;
@@ -28,9 +27,7 @@ public class MensaRemoteViewFactory implements RemoteViewsService.RemoteViewsFac
     @Override
     public void onCreate() {
         CafeteriaManager mensaManager = new CafeteriaManager(mApplicationContext);
-        Map<String, List<CafeteriaMenu>> menus = mensaManager.getBestMatchMensaInfo(mApplicationContext)
-                                                             .blockingFirst();
-        mMenus = menus.get(menus.keySet().iterator().next());
+        mMenus = mensaManager.getBestMatchCafeteriaMenus();
     }
 
     @Override
@@ -51,9 +48,6 @@ public class MensaRemoteViewFactory implements RemoteViewsService.RemoteViewsFac
     @Override
     public RemoteViews getViewAt(int position) {
         CafeteriaMenu currentItem = mMenus.get(position);
-        if (currentItem == null) {
-            return null;
-        }
 
         RemoteViews rv = new RemoteViews(mApplicationContext.getPackageName(), R.layout.mensa_widget_item);
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.java
@@ -37,9 +37,8 @@ public class MensaWidget extends AppWidgetProvider {
             CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
             localRepository.setDb(TcaDb.getInstance(context));
 
-            Cafeteria cafeteria = localRepository
-                    .getCafeteria(mensaManager.getBestMatchMensaId(context))
-                    .blockingFirst();
+            int cafeteriaId = mensaManager.getBestMatchMensaId(context);
+            Cafeteria cafeteria = localRepository.getCafeteria(cafeteriaId);
             rv.setTextViewText(R.id.mensa_widget_header, cafeteria.getName());
 
             // Set the properly formatted date in the subhead

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/MensaWidgetService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/MensaWidgetService.kt
@@ -1,11 +1,9 @@
 package de.tum.`in`.tumcampusapp.service
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.widget.RemoteViewsService
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.widget.MensaRemoteViewFactory
 
-@SuppressLint("Registered")
 class MensaWidgetService : RemoteViewsService() {
 
     override fun onGetViewFactory(intent: Intent): RemoteViewsService.RemoteViewsFactory {


### PR DESCRIPTION
A `blockingFirst()` on a `Flowable` produced a `NoSuchElementException` in `MensaRemoteViewFactory`. When further investigating this, I noticed a number of unnecessary `Flowable` usages. I refactored the questionable parts without `Flowable` and used `Flowable.fromCallable()` if a `Flowable` was actually needed.