### PR TITLE
Completely switch to verification based on device ID

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/AuthenticationManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/AuthenticationManager.java
@@ -270,7 +270,7 @@ public class AuthenticationManager {
             return;
         }
 
-        TUMCabeVerification verification = TUMCabeVerification.createDeviceVerification(mContext, null);
+        TUMCabeVerification verification = TUMCabeVerification.create(mContext, null);
         if (verification == null) {
             Utils.log("Can't upload obfuscated ids: no private key");
             return;

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -129,7 +129,7 @@ public final class TUMCabeClient {
 
     private static TUMCabeVerification getMemberVerification(Context context, Object data) throws NoPrivateKey {
         TUMCabeVerification verification =
-                TUMCabeVerification.createMemberVerification(context, null);
+                TUMCabeVerification.create(context, null);
         if (verification == null) {
             throw new NoPrivateKey();
         }
@@ -139,7 +139,7 @@ public final class TUMCabeClient {
 
     private static TUMCabeVerification getDeviceVerification(Context context, Object data) throws NoPrivateKey {
         TUMCabeVerification verification =
-                TUMCabeVerification.createDeviceVerification(context, data);
+                TUMCabeVerification.create(context, data);
         if (verification == null) {
             throw new NoPrivateKey();
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/model/DeviceUploadFcmToken.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/model/DeviceUploadFcmToken.kt
@@ -14,7 +14,7 @@ data class DeviceUploadFcmToken(
 
         @Throws(NoPrivateKey::class)
         fun getDeviceUploadFcmToken(c: Context, token: String): DeviceUploadFcmToken {
-            val verification = TUMCabeVerification.createDeviceVerification(c) ?: throw NoPrivateKey()
+            val verification = TUMCabeVerification.create(c) ?: throw NoPrivateKey()
             return DeviceUploadFcmToken(
                     verification = verification,
                     token = token,

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/model/TUMCabeVerification.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/model/TUMCabeVerification.kt
@@ -3,8 +3,6 @@ package de.tum.`in`.tumcampusapp.api.app.model
 import android.content.Context
 import de.tum.`in`.tumcampusapp.api.app.AuthenticationManager
 import de.tum.`in`.tumcampusapp.api.app.exception.NoPrivateKey
-import de.tum.`in`.tumcampusapp.component.ui.chat.model.ChatMember
-import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
 import java.math.BigInteger
 import java.security.SecureRandom
@@ -14,41 +12,25 @@ data class TUMCabeVerification(
         val signature: String,
         val date: String,
         val rand: String,
-        val id: String,
+        val device: String,
         var data: Any? = null) {
 
     companion object {
 
         @JvmStatic
-        fun createDeviceVerification(context: Context, data: Any? = null): TUMCabeVerification? {
-            val id = AuthenticationManager.getDeviceID(context)
-            return create(context, id, id, data)
-        }
-
-        @JvmStatic
-        fun createMemberVerification(context: Context, data: Any? = null): TUMCabeVerification? {
-            val chatMember = Utils.getSetting(
-                    context, Const.CHAT_MEMBER, ChatMember::class.java) ?: return null
-
-            val id = chatMember.id.toString()
-            val token = chatMember.lrzId.orEmpty()
-
-            return create(context, id, token, data)
-        }
-
-        @JvmStatic
-        private fun create(context: Context,
-                           id: String, token: String, data: Any? = null): TUMCabeVerification? {
+        fun create(context: Context, data: Any? = null): TUMCabeVerification? {
             val date = Date().toString()
             val rand = BigInteger(130, SecureRandom()).toString(32)
+            val deviceID = AuthenticationManager.getDeviceID(context)
 
             val signature = try {
-                AuthenticationManager(context).sign(date + rand + id)
+                AuthenticationManager(context).sign(date + rand + deviceID)
             } catch (e: NoPrivateKey) {
+                Utils.log(e)
                 return null
             }
 
-            return TUMCabeVerification(signature, date, rand, id, data)
+            return TUMCabeVerification(signature, date, rand, deviceID, data)
         }
 
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/AddChatMemberActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/AddChatMemberActivity.java
@@ -197,7 +197,7 @@ public class AddChatMemberActivity extends BaseActivity {
     }
 
     private void joinRoom(ChatMember member) {
-        TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(this, null);
+        TUMCabeVerification verification = TUMCabeVerification.create(this, null);
         if (verification == null) {
             Utils.showToast(this, R.string.error);
             return;

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatNotification.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatNotification.java
@@ -113,7 +113,7 @@ public class ChatNotification extends GenericNotification implements ChatMessage
         remoteRepository.setTumCabeClient(TUMCabeClient.getInstance(context));
         ChatMessageViewModel chatMessageViewModel = new ChatMessageViewModel(localRepository, remoteRepository, new CompositeDisposable());
 
-        TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(context, null);
+        TUMCabeVerification verification = TUMCabeVerification.create(context, null);
         if (verification == null) {
             return;
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatRoomController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatRoomController.java
@@ -170,8 +170,7 @@ public class ChatRoomController implements ProvidesCard {
                     // Join chat room
                     try {
                         ChatRoom currentChatRoom = new ChatRoom(roomId);
-                        TUMCabeVerification verification =
-                                TUMCabeVerification.createMemberVerification(mContext, null);
+                        TUMCabeVerification verification = TUMCabeVerification.create(mContext, null);
                         if (verification == null) {
                             return results;
                         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/activity/ChatActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/activity/ChatActivity.java
@@ -40,7 +40,6 @@ import java.util.List;
 
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
-import de.tum.in.tumcampusapp.api.app.exception.NoPrivateKey;
 import de.tum.in.tumcampusapp.api.app.model.TUMCabeVerification;
 import de.tum.in.tumcampusapp.component.other.generic.activity.ActivityForDownloadingExternal;
 import de.tum.in.tumcampusapp.component.ui.chat.AddChatMemberActivity;
@@ -396,7 +395,7 @@ public class ChatActivity extends ActivityForDownloadingExternal implements Dial
             // Download chat messages in new Thread
 
             // If currently nothing has been shown load newest messages from server
-            TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(this, null);
+            TUMCabeVerification verification = TUMCabeVerification.create(this, null);
             if (verification == null) {
                 return; //In this case we simply cannot do anything
             }
@@ -440,7 +439,7 @@ public class ChatActivity extends ActivityForDownloadingExternal implements Dial
     @Override
     public void onClick(DialogInterface dialog, int which) {
         // Send request to the server to remove the user from this room
-        TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(this, null);
+        TUMCabeVerification verification = TUMCabeVerification.create(this, null);
         if (verification == null) {
             return;
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/activity/ChatRoomsActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/activity/ChatRoomsActivity.java
@@ -145,8 +145,7 @@ public class ChatRoomsActivity
         Handler handler = new Handler(Looper.getMainLooper());
         handler.post(() -> {
             try {
-                TUMCabeVerification verification =
-                        TUMCabeVerification.createMemberVerification(this, null);
+                TUMCabeVerification verification = TUMCabeVerification.create(this, null);
                 if (verification == null) {
                     runOnUiThread(this::finish);
                 }
@@ -261,7 +260,7 @@ public class ChatRoomsActivity
 
         currentChatRoom = new ChatRoom(name);
 
-        TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(this, null);
+        TUMCabeVerification verification = TUMCabeVerification.create(this, null);
         if (verification == null) {
             finish();
             return;

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
@@ -125,7 +125,7 @@ public class WizNavExtrasActivity extends ActivityForLoadingInBackground<Void, C
 
         // Try to restore already joined chat rooms from server
         try {
-            TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(this, null);
+            TUMCabeVerification verification = TUMCabeVerification.create(this, null);
             List<ChatRoom> rooms = tumCabeClient.getMemberRooms(member.getId(), verification);
             new ChatRoomController(this).replaceIntoRooms(rooms);
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
@@ -163,7 +163,7 @@ public class BuyTicketActivity extends BaseActivity {
         int ticketTypeId = ticketType.getId();
         TicketReservation reservation = new TicketReservation(ticketTypeId);
 
-        TUMCabeVerification verification = TUMCabeVerification.createMemberVerification(this, reservation);
+        TUMCabeVerification verification = TUMCabeVerification.create(this, reservation);
         if (verification == null) {
             handleTicketReservationFailure(R.string.internal_error);
             return;


### PR DESCRIPTION
This commits removes the ChatMemberVerification and only uses the device ID as provided by the AuthenticationManager.