### PR TITLE
Enable Gradle daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1536M
 # org.gradle.parallel=true
 # Gradle recommends to disable the Daemon for Continuous Integration and build server environments:
 # https://docs.gradle.org/current/userguide/gradle_daemon.html#when_should_i_not_use_the_gradle_daemon
-org.gradle.daemon=false
+org.gradle.daemon=true
 # Non ASCII characters in environment variables seem to crash gradle
 # https://stackoverflow.com/a/46673006
 file.encoding=utf-8


### PR DESCRIPTION
This commit enables the Gradle daemon for faster build times, as Gradle no longer generally recommends to disable the daemon for CI builds.