### PR TITLE
Fix NullPointerException in MVVWidget

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidgetConfigureActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidgetConfigureActivity.kt
@@ -147,12 +147,9 @@ class MVVWidgetConfigureActivity :
      * Saves the selection to the database, triggers a widget update and closes this activity
      */
     private fun saveAndReturn() {
-        // save the settingsPrefix
+        // save the settings
         val transportManager = TransportController(this)
         transportManager.addWidget(appWidgetId, widgetDepartures)
-
-        // update alarms
-        MVVWidget.setAlarm(this)
 
         // update widget
         val reloadIntent = Intent(this, MVVWidget::class.java)


### PR DESCRIPTION
Make `TransportController` non-static to avoid memory leaks (as it holds a reference to a `Context`) and move its initialization to `MVVWidget.onReceive()`, which is the main entry point of the widget.