### PR TITLE
Add null check in CalendarActivity to prevent IllegalArgumentException

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -98,6 +98,7 @@
       <option name="useParameterizedTypeForCollectionMethods" value="true" />
       <option name="doNotWeakenToJavaLangObject" value="true" />
       <option name="onlyWeakentoInterface" value="true" />
+      <stopClasses>java.util.List</stopClasses>
     </inspection_tool>
     <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryConstructor" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/TUMOnlineAPIService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/TUMOnlineAPIService.kt
@@ -4,7 +4,7 @@ import de.tum.`in`.tumcampusapp.api.tumonline.model.AccessToken
 import de.tum.`in`.tumcampusapp.api.tumonline.model.TokenConfirmation
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.CreateEventResponse
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.DeleteEventResponse
-import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.Events
+import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.EventsResponse
 import de.tum.`in`.tumcampusapp.component.tumui.grades.model.ExamList
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LectureAppointmentsResponse
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LectureDetailsResponse
@@ -25,7 +25,7 @@ interface TUMOnlineAPIService {
             @Query("pMonateVor") start: Int,
             @Query("pMonateNach") end: Int,
             @Header("Cache-Control") cacheControl: String
-    ): Call<Events>
+    ): Call<EventsResponse>
 
     @GET("wbservicesbasic.terminCreate")
     fun createCalendarEvent(

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/TUMOnlineClient.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/TUMOnlineClient.kt
@@ -13,7 +13,7 @@ import de.tum.`in`.tumcampusapp.api.tumonline.model.TokenConfirmation
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.CalendarItem
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.CreateEventResponse
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.DeleteEventResponse
-import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.Events
+import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.EventsResponse
 import de.tum.`in`.tumcampusapp.component.tumui.grades.model.ExamList
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LectureAppointmentsResponse
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LectureDetailsResponse
@@ -30,7 +30,7 @@ import retrofit2.Retrofit
 
 class TUMOnlineClient(private val apiService: TUMOnlineAPIService) {
 
-    fun getCalendar(cacheControl: CacheControl): Call<Events> {
+    fun getCalendar(cacheControl: CacheControl): Call<EventsResponse> {
         return apiService.getCalendar(
                 Const.CALENDAR_MONTHS_BEFORE, Const.CALENDAR_MONTHS_AFTER, cacheControl.header)
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.java
@@ -34,7 +34,6 @@ import de.tum.in.tumcampusapp.component.other.locations.RoomLocationsDao;
 import de.tum.in.tumcampusapp.component.other.locations.model.Geo;
 import de.tum.in.tumcampusapp.component.tumui.calendar.model.CalendarItem;
 import de.tum.in.tumcampusapp.component.tumui.calendar.model.Event;
-import de.tum.in.tumcampusapp.component.tumui.calendar.model.Events;
 import de.tum.in.tumcampusapp.component.tumui.calendar.model.WidgetsTimetableBlacklist;
 import de.tum.in.tumcampusapp.component.tumui.lectures.model.RoomLocations;
 import de.tum.in.tumcampusapp.component.ui.overview.card.Card;
@@ -212,18 +211,15 @@ public class CalendarController implements ProvidesCard, ProvidesNotifications {
         scheduler.schedule(notifications);
     }
 
-    public void importCalendar(Events newEvents) {
+    public void importCalendar(@NonNull List<Event> events) {
         // Cleanup cache before importing
         removeCache();
 
         // Import the new events
-        List<Event> events = newEvents.getEvents();
-        if (events != null) {
-            try {
-                replaceIntoDb(events);
-            } catch (Exception e) {
-                Utils.log(e);
-            }
+        try {
+            replaceIntoDb(events);
+        } catch (Exception e) {
+            Utils.log(e);
         }
 
         new SyncManager(mContext).replaceIntoDb(Const.SYNC_CALENDAR_IMPORT);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/EventsResponse.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/EventsResponse.kt
@@ -10,4 +10,4 @@ import com.tickaroo.tikxml.annotation.Xml
  * @see LecturesSearchRow
  */
 @Xml(name = "events")
-data class Events(@Element val events: List<Event>? = null)
+data class EventsResponse(@Element val events: List<Event>? = null)

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
@@ -5,7 +5,7 @@ import de.tum.`in`.tumcampusapp.api.tumonline.AccessTokenManager
 import de.tum.`in`.tumcampusapp.api.tumonline.CacheControl
 import de.tum.`in`.tumcampusapp.api.tumonline.TUMOnlineClient
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.CalendarController
-import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.Events
+import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.EventsResponse
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LecturesResponse
 import de.tum.`in`.tumcampusapp.component.ui.chat.ChatRoomController
 import okhttp3.Cache
@@ -32,14 +32,15 @@ class CacheManager(private val context: Context) {
         TUMOnlineClient
                 .getInstance(context)
                 .getCalendar(CacheControl.USE_CACHE)
-                .enqueue(object : Callback<Events> {
-                    override fun onResponse(call: Call<Events>, response: Response<Events>) {
-                        val events = response.body() ?: return
+                .enqueue(object : Callback<EventsResponse> {
+                    override fun onResponse(call: Call<EventsResponse>, response: Response<EventsResponse>) {
+                        val eventsResponse = response.body() ?: return
+                        val events = eventsResponse.events ?: return
                         CalendarController(context).importCalendar(events)
                         loadRoomLocations()
                     }
 
-                    override fun onFailure(call: Call<Events>, t: Throwable) {
+                    override fun onFailure(call: Call<EventsResponse>, t: Throwable) {
                         Utils.log(t, "Error while loading calendar in CacheManager")
                     }
                 })


### PR DESCRIPTION
This commit checks whether the list of events, as returned by the TUMonline API, is null. Only if it is not, it will invoke the methods that perform the scheduling of the corresponding notifications.