### PR TITLE
Make tweaks to calendar design and behavior

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,7 +146,7 @@ dependencies {
     implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
     implementation 'de.psdev.licensesdialog:licensesdialog:1.8.3'
-    implementation 'com.github.thellmund:Android-Week-View:2.0'
+    implementation 'com.github.thellmund:Android-Week-View:2.0.1'
     implementation 'de.hdodenhof:circleimageview:2.2.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
@@ -27,6 +27,7 @@ import com.alamkanak.weekview.WeekViewEvent;
 
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -45,7 +46,6 @@ import de.tum.in.tumcampusapp.component.tumui.calendar.model.EventsResponse;
 import de.tum.in.tumcampusapp.component.ui.transportation.TransportController;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Const;
-import de.tum.in.tumcampusapp.utils.DateTimeUtils;
 import de.tum.in.tumcampusapp.utils.Utils;
 import io.reactivex.Completable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -250,7 +250,10 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
                 deleteCalendarFromGoogle();
                 return true;
             case R.id.action_create_event:
-                startActivity(new Intent(this, CreateEventActivity.class));
+                LocalDate currentDate = new LocalDate(mWeekView.getFirstVisibleDay());
+                Intent intent = new Intent(this, CreateEventActivity.class);
+                intent.putExtra(Const.DATE, currentDate);
+                startActivity(intent);
                 return true;
             case R.id.action_calendar_filter_canceled:
                 item.setChecked(!item.isChecked());
@@ -455,8 +458,8 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
         bundle.putBoolean(Const.EVENT_EDIT, true);
         bundle.putString(Const.EVENT_TITLE, calendarItem.getTitle());
         bundle.putString(Const.EVENT_COMMENT, calendarItem.getDescription());
-        bundle.putString(Const.EVENT_START, DateTimeUtils.INSTANCE.getDateTimeString(calendarItem.getDtstart()));
-        bundle.putString(Const.EVENT_END, DateTimeUtils.INSTANCE.getDateTimeString(calendarItem.getDtend()));
+        bundle.putSerializable(Const.EVENT_START, calendarItem.getDtstart());
+        bundle.putSerializable(Const.EVENT_END, calendarItem.getDtend());
         bundle.putString(Const.EVENT_NR, calendarItem.getNr());
         Intent intent = new Intent(this, CreateEventActivity.class);
         intent.putExtras(bundle);
@@ -477,11 +480,6 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
         detailsFragment.show(getSupportFragmentManager(), null);
     }
 
-    protected void onResume() {
-        super.onResume();
-        refreshWeekView();
-    }
-
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
@@ -499,15 +497,6 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
         }
     }
 
-    protected int calcHourHeightToFit(int min, int max) {
-        // get the height of the weekView and subtract the height of its header
-        // to get height of actual calendar section, then divide by 24 to get height of a single hour
-        return (mWeekView.getMeasuredHeight()             // height of weekView
-                - mWeekView.getTextSize()                 // height of text in header of weekView
-                - (3 * mWeekView.getHeaderRowPadding()))    // height of padding above and below text in header
-               / (max - min);                             // amount of hours
-    }
-
     protected void initFilterCheckboxes() {
         boolean settings = Utils.getSettingBool(this, Const.CALENDAR_FILTER_CANCELED, true);
         menuItemFilterCanceled.setChecked(settings);
@@ -517,13 +506,6 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
     protected void applyFilterCanceled(boolean val) {
         Utils.setSetting(this, Const.CALENDAR_FILTER_CANCELED, val);
         refreshWeekView();
-    }
-
-    protected void hourHeightFitScreen() {
-        int minHour = Integer.parseInt(Utils.getSetting(this, Const.CALENDAR_FILTER_HOUR_LIMIT_MIN, Const.CALENDAR_FILTER_HOUR_LIMIT_MIN_DEFAULT));
-        int maxHour = Integer.parseInt(Utils.getSetting(this, Const.CALENDAR_FILTER_HOUR_LIMIT_MAX, Const.CALENDAR_FILTER_HOUR_LIMIT_MAX_DEFAULT));
-        int hourHeight = calcHourHeightToFit(minHour, maxHour);
-        mWeekView.setHourHeight(hourHeight);
     }
 
     @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
@@ -278,14 +278,14 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
             mWeekView.setNumberOfVisibleDays(5);
             // Lets change some dimensions to best fit the view.
             mWeekView.setTextSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12, getResources().getDisplayMetrics()));
-            mWeekView.setEventTextSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 10, getResources().getDisplayMetrics()));
+            mWeekView.setEventTextSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12, getResources().getDisplayMetrics()));
             mWeekView.setXScrollingSpeed(1);
         } else {
             icon = R.drawable.ic_outline_view_column_24px;
             mWeekView.setNumberOfVisibleDays(1);
             // Lets change some dimensions to best fit the view.
             mWeekView.setTextSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 16, getResources().getDisplayMetrics()));
-            mWeekView.setEventTextSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12, getResources().getDisplayMetrics()));
+            mWeekView.setEventTextSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 14, getResources().getDisplayMetrics()));
             mWeekView.setXScrollingSpeed(0.4f);
         }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarDetailsFragment.kt
@@ -4,7 +4,6 @@ import android.app.SearchManager
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.support.design.widget.BottomSheetDialogFragment
 import android.support.v7.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
@@ -20,12 +19,13 @@ import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Const.CALENDAR_ID_PARAM
 import de.tum.`in`.tumcampusapp.utils.Utils
+import de.tum.`in`.tumcampusapp.utils.ui.RoundedBottomSheetDialogFragment
 import kotlinx.android.synthetic.main.fragment_calendar_details.*
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-class CalendarDetailsFragment : BottomSheetDialogFragment() {
+class CalendarDetailsFragment : RoundedBottomSheetDialogFragment() {
 
     private lateinit var listener: OnEventInteractionListener
     private lateinit var dao: CalendarDao

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -31,7 +32,6 @@ import de.tum.in.tumcampusapp.component.tumui.calendar.model.CreateEventResponse
 import de.tum.in.tumcampusapp.component.tumui.calendar.model.DeleteEventResponse;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Const;
-import de.tum.in.tumcampusapp.utils.DateTimeUtils;
 import de.tum.in.tumcampusapp.utils.Utils;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -131,9 +131,25 @@ public class CreateEventActivity extends ActivityForAccessingTumOnline<CreateEve
     }
 
     private void initStartEndDates(Bundle extras) {
-        if (extras != null) { // editing indicates extras are not null
-            start = DateTimeUtils.INSTANCE.getDateTime(extras.getString(Const.EVENT_START));
-            end = DateTimeUtils.INSTANCE.getDateTime(extras.getString(Const.EVENT_END));
+        LocalDate initialDate = (LocalDate) extras.getSerializable(Const.DATE);
+        start = (DateTime) extras.getSerializable(Const.EVENT_START);
+        end = (DateTime) extras.getSerializable(Const.EVENT_END);
+
+        if (start == null || end == null) {
+            if (initialDate == null) {
+                throw new IllegalStateException("No date provided for CreateEventActivity");
+            }
+
+            // We’re creating a new event, so we set the start and end time to the next full hour
+            start = initialDate.toDateTimeAtCurrentTime()
+                    .plusHours(1)
+                    .withMinuteOfHour(0)
+                    .withSecondOfMinute(0)
+                    .withMillisOfSecond(0);
+            end = start.plusHours(1);
+        }
+
+        /*
         } else {
             // initial start: round up to the next full hour
             start = new DateTime()
@@ -144,6 +160,7 @@ public class CreateEventActivity extends ActivityForAccessingTumOnline<CreateEve
             end = new DateTime(start)
                     .plusHours(1);
         }
+        */
 
         updateDateViews();
         updateTimeViews();

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/ui/RoundedBottomSheetDialogFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/ui/RoundedBottomSheetDialogFragment.kt
@@ -1,0 +1,17 @@
+package de.tum.`in`.tumcampusapp.utils.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import android.support.design.widget.BottomSheetDialog
+import android.support.design.widget.BottomSheetDialogFragment
+import de.tum.`in`.tumcampusapp.R
+
+open class RoundedBottomSheetDialogFragment : BottomSheetDialogFragment() {
+
+    override fun getTheme() = R.style.BottomSheetDialogTheme
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return BottomSheetDialog(requireContext(), theme)
+    }
+
+}

--- a/app/src/main/res/drawable/bottom_sheet_background.xml
+++ b/app/src/main/res/drawable/bottom_sheet_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+    <corners
+        android:topLeftRadius="@dimen/material_corner_radius"
+        android:topRightRadius="@dimen/material_corner_radius" />
+    <padding android:top="@dimen/material_small_padding" />
+</shape>

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -27,14 +27,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
 
-                <!-- TODO: Improve design -->
                 <com.alamkanak.weekview.WeekView
                     android:id="@+id/weekView"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     app:columnGap="8dp"
-                    app:dayBackgroundColor="#05000000"
+                    app:dayBackgroundColor="@android:color/white"
                     app:eventCornerRadius="4dp"
+                    app:eventPadding="6dp"
                     app:eventTextColor="@android:color/white"
                     app:headerColumnBackground="#ffffffff"
                     app:headerColumnPadding="8dp"
@@ -43,8 +43,9 @@
                     app:headerRowPadding="12dp"
                     app:hourHeight="60dp"
                     app:noOfVisibleDays="3"
-                    app:overlappingEventGap="4dp"
-                    app:textSize="12sp"
+                    app:overlappingEventGap="@dimen/material_small_padding"
+                    app:singleDayHorizontalMargin="@dimen/material_small_padding"
+                    app:textSize="14sp"
                     app:todayBackgroundColor="#1848adff"
                     app:todayHeaderTextColor="@color/color_primary" />
 

--- a/app/src/main/res/layout/fragment_calendar_details.xml
+++ b/app/src/main/res/layout/fragment_calendar_details.xml
@@ -99,9 +99,9 @@
             android:id="@+id/buttonsContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/material_small_padding"
+            android:layout_marginStart="@dimen/material_default_padding"
             android:layout_marginTop="@dimen/material_small_padding"
-            android:layout_marginEnd="@dimen/material_small_padding"
+            android:layout_marginEnd="@dimen/material_default_padding"
             android:layout_marginBottom="@dimen/material_small_padding"
             android:gravity="end"
             android:orientation="horizontal">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -199,4 +199,18 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="BottomDialog" parent="@style/Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/bottom_sheet_background</item>
+    </style>
+
+    <style name="BaseBottomSheetDialog" parent="@style/Theme.Design.Light.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="bottomSheetStyle">@style/BottomDialog</item>
+    </style>
+
+    <style name="BottomSheetDialogTheme" parent="BaseBottomSheetDialog">
+        <item name="android:statusBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
+        <item name="android:navigationBarColor" tools:targetApi="lollipop">@android:color/white</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
- Update design of `CalendarDetailsFragment` (see below; let me know if something looks off on non-Pixel devices)
- Update to 2.0.1 of [my fork of WeekView](https://github.com/thellmund/Android-Week-View), which adds horizontal start and end margins
- Update behavior when creating a new calendar event (now uses the date last visible in the `WeekView` component)

---

Old: 
![screenshot_20180919-170943](https://user-images.githubusercontent.com/11819826/45768337-e886ad00-bc3c-11e8-8ea6-6e592ff9acf4.png)

New: 
![screenshot_20180919-171418](https://user-images.githubusercontent.com/11819826/45768338-e886ad00-bc3c-11e8-87f8-919695cc9344.png)
