### PR TITLE
Switch status bar to lighter gray

### DIFF
--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -2,11 +2,9 @@
 <resources>
     <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="colorPrimary">@color/tum_light_gray</item>
-        <item name="colorPrimaryDark">@color/tum_dark_gray</item>
+        <item name="colorPrimaryDark">@color/tum_light_gray</item>
         <item name="colorAccent">@color/tum_blue</item>
-
         <item name="android:windowBackground">@color/default_window_background</item>
-
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="android:textCursorDrawable">@drawable/cursor_text_field_colorful</item>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,24 +2,20 @@
 
     <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="colorPrimary">@color/tum_light_gray</item>
-        <item name="colorPrimaryDark">@color/tum_dark_gray</item>
+        <item name="colorPrimaryDark">@color/tum_light_gray</item>
         <item name="colorAccent">@color/tum_blue</item>
-
         <item name="android:windowBackground">@color/default_window_background</item>
-
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
         <item name="android:textCursorDrawable">@drawable/cursor_text_field_colorful</item>
 
-        <!-- Light status bar -->
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
-
         <!-- Light system UI -->
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="AppTheme.NoDrawerLayout" parent="AppTheme">
-        <item name="android:statusBarColor">@color/tum_dark_gray</item>
+        <item name="android:statusBarColor">@color/tum_light_gray</item>
     </style>
 
     <style name="TumToolbar" parent="ThemeOverlay.AppCompat.Dark">


### PR DESCRIPTION
This commit switches the status bar color to a lighter gray for a more harmonious look.

---

Old: 
![screenshot_20180926-104438](https://user-images.githubusercontent.com/11819826/46068810-4bff6600-c17a-11e8-8c8e-d7d694ae1c55.png)

New:
![screenshot_20180926-104359](https://user-images.githubusercontent.com/11819826/46068801-473ab200-c17a-11e8-90cc-23f294617c41.png)