### PR TITLE
Fix ActivityNotFoundException in InfoActivity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
@@ -3,11 +3,12 @@ package de.tum.`in`.tumcampusapp.component.ui.overview
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
-import android.content.pm.PackageManager
+import android.content.Intent.ACTION_VIEW
 import android.content.pm.PackageManager.NameNotFoundException
 import android.net.Uri
 import android.os.Bundle
 import android.preference.PreferenceManager
+import android.support.v4.content.pm.PackageInfoCompat
 import android.text.format.DateUtils
 import android.view.View
 import android.view.ViewGroup
@@ -34,16 +35,16 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
         this.displayDebugInfo()
 
         button_facebook.setOnClickListener {
-            openFacebook();
+            openFacebook()
         }
         button_github.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.github_link))))
+            startActivity(Intent(ACTION_VIEW, Uri.parse(getString(R.string.github_link))))
         }
         button_privacy.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy))))
+            startActivity(Intent(ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy))))
         }
         button_chat_terms.setOnClickListener {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_chat_terms))))
+            startActivity(Intent(ACTION_VIEW, Uri.parse(getString(R.string.url_chat_terms))))
         }
         button_licenses.setOnClickListener {
             LicensesDialog.Builder(this)
@@ -55,16 +56,24 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
         }
     }
 
+    /**
+     * Open the Facebook app or view page in a browser if Facebook is not installed
+     */
     private fun openFacebook() {
-        // Open the Facebook app or view page in a browser if Facebook is not installed
+        val default = Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.facebook_link)))
         val facebook = try {
             packageManager.getPackageInfo("com.facebook.katana", 0)
             Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.facebook_link_app)))
-        } catch (e: PackageManager.NameNotFoundException) {
-            Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.facebook_link)))
+        } catch (e: Exception) {
+            default
         }
 
-        startActivity(facebook)
+        try {
+            startActivity(facebook)
+        } catch (e: Exception) {
+            // Don't make any assumptions about another app, just start the browser instead
+            startActivity(default)
+        }
     }
 
     private fun displayDebugInfo() {
@@ -82,7 +91,7 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
         if (token == "") {
             this.addDebugRow(debugInfos, "TUM access token", "")
         } else {
-            this.addDebugRow(debugInfos, "TUM access token", token.substring(0, 5) + "...")
+            this.addDebugRow(debugInfos, "TUM access token", token?.substring(0, 5) + "...")
         }
         this.addDebugRow(debugInfos, "Bug reports", sp.getBoolean(Const.BUG_REPORTS, false).toString() + " ")
 
@@ -92,7 +101,7 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
                 DateUtils.MINUTE_IN_MILLIS, DateUtils.DAY_IN_MILLIS * 2, 0).toString())
         try {
             val packageInfo = packageManager.getPackageInfo(packageName, 0)
-            this.addDebugRow(debugInfos, "Version code", packageInfo.versionCode.toString())
+            this.addDebugRow(debugInfos, "Version code", PackageInfoCompat.getLongVersionCode(packageInfo).toString())
         } catch (ignore: NameNotFoundException) {
         }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
@@ -57,21 +57,16 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
     }
 
     /**
-     * Open the Facebook app or view page in a browser if Facebook is not installed
+     * Open the Facebook app or view page in a browser if Facebook is not installed.
      */
     private fun openFacebook() {
-        val default = Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.facebook_link)))
-        val facebook = try {
-            packageManager.getPackageInfo("com.facebook.katana", 0)
-            Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.facebook_link_app)))
-        } catch (e: Exception) {
-            default
-        }
-
         try {
-            startActivity(facebook)
+            packageManager.getPackageInfo("com.facebook.katana", 0)
+            val intent = Intent(ACTION_VIEW, Uri.parse(getString(R.string.facebook_link_app)))
+            startActivity(intent)
         } catch (e: Exception) {
             // Don't make any assumptions about another app, just start the browser instead
+            val default = Intent(ACTION_VIEW, Uri.parse(getString(R.string.facebook_link)))
             startActivity(default)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="information">Information</string>
     <string name="facebook" translatable="false">Facebook</string>
     <string name="facebook_link" translatable="false">https://m.facebook.com/TUMCampus</string>
-    <string name="facebook_link_app" translatable="false">fb://page/162327853831856</string>
+    <string name="facebook_link_app" translatable="false">fb://facewebmodal/f?href=https://www.facebook.com/TUMCampus</string>
     <string name="github" translatable="false">GitHub</string>
     <string name="github_contribute">Contribute on GitHub</string>
     <string name="github_link" translatable="false">https://github.com/TCA-Team/TumCampusApp</string>


### PR DESCRIPTION
The app crashes on the most recent beta when opening the Facebook link, when the Facebook App is installed with a ActivityNotFoundException.

Some Stackoverflow answers suggest (https://stackoverflow.com/a/24547437, https://stackoverflow.com/a/34564284), the FB App does not accept the URI we're trying to feed it since 2014 :hankey: 
I guess either nobody has the FB App installed anymore, or people simply do not like to click that link :man_shrugging: 

Do we even care? In the SupportCard we just open the browser in any case...