### PR TITLE
InstantRun doesn't play nicely with shrinkResources.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
             proguardFiles(file('../proguard').listFiles())
             proguardFile getDefaultProguardFile('proguard-android.txt')
             minifyEnabled true
-            shrinkResources true
+            shrinkResources false
             useProguard true
         }
         release.debuggable false


### PR DESCRIPTION
Disable it for now
This fixes the Circular dependency issue discussed in #1134