### PR TITLE
remove deprecated FirebaseInstanceIdService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -637,18 +637,11 @@
             android:exported="false" />
         <service
             android:name=".service.FcmReceiverService"
+            android:stopWithTask="false"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-        <service
-            android:name=".service.FcmIdentificationService"
-            android:enabled="true"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
             </intent-filter>
         </service>
         <service

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/AuthenticationManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/AuthenticationManager.java
@@ -28,7 +28,7 @@ import de.tum.in.tumcampusapp.api.app.model.UploadStatus;
 import de.tum.in.tumcampusapp.api.tumonline.TUMOnlineClient;
 import de.tum.in.tumcampusapp.api.tumonline.model.TokenConfirmation;
 import de.tum.in.tumcampusapp.component.ui.chat.model.ChatMember;
-import de.tum.in.tumcampusapp.service.FcmIdentificationService;
+import de.tum.in.tumcampusapp.service.FcmTokenHandler;
 import de.tum.in.tumcampusapp.utils.Const;
 import de.tum.in.tumcampusapp.utils.RSASigner;
 import de.tum.in.tumcampusapp.utils.Utils;
@@ -257,8 +257,7 @@ public class AuthenticationManager {
         if (Utils.getSettingBool(mContext, Const.PUBLIC_KEY_UPLOADED, false)
             && GoogleApiAvailability.getInstance()
                                     .isGooglePlayServicesAvailable(mContext) == ConnectionResult.SUCCESS) {
-            FcmIdentificationService idService = new FcmIdentificationService();
-            idService.checkSetup(mContext);
+            FcmTokenHandler.checkSetup(mContext);
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/FcmReceiverService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/FcmReceiverService.kt
@@ -19,6 +19,7 @@ package de.tum.`in`.tumcampusapp.service
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Bundle
+import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
@@ -26,6 +27,7 @@ import de.tum.`in`.tumcampusapp.component.other.general.Update
 import de.tum.`in`.tumcampusapp.component.other.generic.GenericNotification
 import de.tum.`in`.tumcampusapp.component.ui.alarm.AlarmNotification
 import de.tum.`in`.tumcampusapp.component.ui.chat.ChatNotification
+import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
 import java.io.IOException
 
@@ -100,6 +102,13 @@ class FcmReceiverService : FirebaseMessagingService() {
             }
 
         }
+    }
+
+    override fun onNewToken(token: String?) {
+        super.onNewToken(token)
+        Utils.log("new FCM token received")
+        Utils.setSetting(this, Const.FCM_INSTANCE_ID, FirebaseInstanceId.getInstance().id)
+        Utils.setSetting(this, Const.FCM_TOKEN_ID, token ?: "")
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/FcmTokenHandler.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/FcmTokenHandler.kt
@@ -1,43 +1,28 @@
 package de.tum.`in`.tumcampusapp.service
 
 import android.content.Context
+import com.google.android.gms.tasks.OnSuccessListener
 import com.google.firebase.iid.FirebaseInstanceId
-import com.google.firebase.iid.FirebaseInstanceIdService
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
 import de.tum.`in`.tumcampusapp.api.app.model.DeviceUploadFcmToken
 import de.tum.`in`.tumcampusapp.api.app.model.TUMCabeStatus
-import de.tum.`in`.tumcampusapp.utils.Const
+import de.tum.`in`.tumcampusapp.utils.Const.FCM_INSTANCE_ID
+import de.tum.`in`.tumcampusapp.utils.Const.FCM_REG_ID_LAST_TRANSMISSION
+import de.tum.`in`.tumcampusapp.utils.Const.FCM_REG_ID_SENT_TO_SERVER
+import de.tum.`in`.tumcampusapp.utils.Const.FCM_TOKEN_ID
 import de.tum.`in`.tumcampusapp.utils.Utils
 import de.tum.`in`.tumcampusapp.utils.tryOrNull
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.io.IOException
 import java.util.*
+import java.util.concurrent.Executors
 
-class FcmIdentificationService : FirebaseInstanceIdService() {
+object FcmTokenHandler {
 
-    /**
-     * Registers this phone with InstanceID and returns a valid token to be transmitted to the server
-     *
-     * @return String token that can be used to transmit messages to this client
-     */
-    @Throws(IOException::class)
-    private fun register(context: Context): String? {
-        val instanceID = FirebaseInstanceId.getInstance()
-        val token = instanceID.token
-        Utils.setSetting(context, Const.FCM_INSTANCE_ID, instanceID.id)
-        Utils.setSetting(context, Const.FCM_TOKEN_ID, token ?: "")
-        return token
-    }
-
-    override fun onTokenRefresh() {
-        val refreshedToken = FirebaseInstanceId.getInstance().token
-        Utils.setSetting(this, Const.FCM_TOKEN_ID, refreshedToken ?: "")
-    }
-
+    @JvmStatic
     fun checkSetup(context: Context) {
-        val currentToken = Utils.getSetting(context, Const.FCM_TOKEN_ID, "")
+        val currentToken = Utils.getSetting(context, FCM_TOKEN_ID, "")
 
         // If we failed, we need to re register
         if (currentToken.isEmpty()) {
@@ -45,7 +30,7 @@ class FcmIdentificationService : FirebaseInstanceIdService() {
         } else {
             // If the regId is not empty, we still need to check whether it was successfully sent to the
             // TCA server, because this can fail due to user not confirming their private key
-            if (!Utils.getSettingBool(context, Const.FCM_REG_ID_SENT_TO_SERVER, false)) {
+            if (!Utils.getSettingBool(context, FCM_REG_ID_SENT_TO_SERVER, false)) {
                 sendTokenToBackend(context, currentToken)
             }
 
@@ -62,21 +47,22 @@ class FcmIdentificationService : FirebaseInstanceIdService() {
      * shared preferences.
      */
     private fun registerInBackground(context: Context) {
-        try {
-            //Register a new ID
-            val token = register(context)
+        val executor = Executors.newSingleThreadExecutor()
+        FirebaseInstanceId.getInstance().instanceId.addOnSuccessListener(executor,
+                OnSuccessListener { instanceIdResult ->
+                    val token = instanceIdResult.token
+                    Utils.setSetting(context, FCM_INSTANCE_ID, instanceIdResult.id)
+                    Utils.setSetting(context, FCM_TOKEN_ID, token)
 
-            //Reset the lock in case we are updating and maybe failed
-            Utils.setSetting(context, Const.FCM_REG_ID_SENT_TO_SERVER, false)
-            Utils.setSetting(context, Const.FCM_REG_ID_LAST_TRANSMISSION, Date().time)
+                    // Reset the lock in case we are updating and maybe failed
+                    Utils.setSetting(context, FCM_REG_ID_SENT_TO_SERVER, false)
+                    Utils.setSetting(context, FCM_REG_ID_LAST_TRANSMISSION, Date().time)
 
-            // Let the server know of our new registration ID
-            sendTokenToBackend(context, token)
+                    // Let the server know of our new registration ID
+                    sendTokenToBackend(context, token)
 
-            Utils.log("GCM registration successful")
-        } catch (e: IOException) {
-            Utils.log(e)
-        }
+                    Utils.log("FCM registration successful")
+                })
     }
 
     /**
@@ -86,35 +72,36 @@ class FcmIdentificationService : FirebaseInstanceIdService() {
      * using the 'from' address in the message.
      */
     private fun sendTokenToBackend(context: Context, token: String?) {
-        //Check if all parameters are present
+        // Check if all parameters are present
         if (token == null || token.isEmpty()) {
             Utils.logv("Parameter missing for sending reg id")
             return
         }
 
         // Try to create the message
-        val uploadToken = tryOrNull { DeviceUploadFcmToken.getDeviceUploadFcmToken(context, token) } ?: return
+        val uploadToken = tryOrNull { DeviceUploadFcmToken.getDeviceUploadFcmToken(context, token) }
+                ?: return
 
         TUMCabeClient
                 .getInstance(context)
                 .deviceUploadGcmToken(uploadToken, object : Callback<TUMCabeStatus> {
                     override fun onResponse(call: Call<TUMCabeStatus>, response: Response<TUMCabeStatus>) {
                         if (!response.isSuccessful) {
-                            Utils.logv("Uploading GCM registration failed...")
+                            Utils.logv("Uploading FCM registration failed...")
                             return
                         }
 
                         val body = response.body() ?: return
-                        Utils.logv("Success uploading GCM registration id: " + body.status)
+                        Utils.logv("Success uploading FCM registration id: ${body.status}")
 
                         // Store in shared preferences the information that the GCM registration id
                         // was sent to the TCA server successfully
-                        Utils.setSetting(context, Const.FCM_REG_ID_SENT_TO_SERVER, true)
+                        Utils.setSetting(context, FCM_REG_ID_SENT_TO_SERVER, true)
                     }
 
                     override fun onFailure(call: Call<TUMCabeStatus>, t: Throwable) {
-                        Utils.log(t, "Failure uploading GCM registration id")
-                        Utils.setSetting(context, Const.FCM_REG_ID_SENT_TO_SERVER, false)
+                        Utils.log(t, "Failure uploading FCM registration id")
+                        Utils.setSetting(context, FCM_REG_ID_SENT_TO_SERVER, false)
                     }
                 })
     }
@@ -126,7 +113,7 @@ class FcmIdentificationService : FirebaseInstanceIdService() {
      */
     private fun checkRegisterIdUpdate(context: Context, regId: String) {
         // Regularly (once a day) update the server with the reg id
-        val lastTransmission = Utils.getSettingLong(context, Const.FCM_REG_ID_LAST_TRANSMISSION, 0L)
+        val lastTransmission = Utils.getSettingLong(context, FCM_REG_ID_LAST_TRANSMISSION, 0L)
         val now = Date()
         if (now.time - 24 * 3600000 > lastTransmission) {
             sendTokenToBackend(context, regId)


### PR DESCRIPTION
This fixes #1110
I also replaced the "GCM" in the log messages, so filtering for "FCM" should now show all log messages for the tokens, to quickly check if the FCM registration worked.
