### PR TITLE
Improve/Fix event titles

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarDetailsFragment.kt
@@ -61,7 +61,7 @@ class CalendarDetailsFragment : RoundedBottomSheetDialogFragment() {
             descriptionTextView.setTextColor(Color.RED)
         }
 
-        titleTextView.text = calendarItem.title
+        titleTextView.text = calendarItem.getFormattedTitle()
         dateTextView.text = calendarItem.getEventDateString()
 
         val locationList = calendarItemList.map { it.location }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
@@ -60,13 +60,13 @@ data class CalendarItem(@PrimaryKey
      * Formats title to exclude codes
      */
     fun getFormattedTitle(): String {
-        return Pattern.compile("\\([A-Z0-9\\.]+\\)")
-                .matcher(Pattern.compile("\\([A-Z]+[0-9]+\\)")
-                        .matcher(Pattern.compile("[A-Z, 0-9(LV\\.Nr)=]+$")
-                                .matcher(title)
-                                .replaceAll(""))
+        // remove lecture codes in round or square brackets e.g. (IN0003), [MA0902]
+        return Pattern.compile("[(\\[][A-Z0-9.]+[)\\]]")
+                // remove type of lecture (VO, UE, SE, PR) at the end of the line
+                .matcher(Pattern.compile(" (UE|VO|SE|PR)$")
+                        .matcher(title)
                         .replaceAll(""))
-                .replaceAll("")!!
+                .replaceAll("")
                 .trim { it <= ' ' }
     }
 


### PR DESCRIPTION
## Issue
This fixes the following issue(s): #970 
- doesn't remove numbers outside of brackets anymore
- doesn't remove random capital letters from the end of the title anymore
- also removes lecture numbers in square brackets
- uses the formatted title in the bottom sheet as well (if lecture numbers are needed the user can look them up in My Lectures)

Tested for titles mentioned in the issue and my own events.

## Why this is useful for all students
Titles are displayed correctly again
