### PR TITLE
update mensa garching opening time

### DIFF
--- a/app/src/main/assets/locations.csv
+++ b/app/src/main/assets/locations.csv
@@ -12,7 +12,7 @@
 1012;library;Studentenwerksbibliothek (LMU);Leopoldstr. 13 Haus 1;;U3/U6 Giselastr;Mo-Fr 8-20;TU-Ausweis bei Zentralbibliothek LMU,\nGeschwister-Scholl-Platz 1, Mo-Fr 9-17;http://www.ub.uni-muenchen.de/bibliotheken/bibs-a-bis-z/0050/index.html
 1013;library;Wirtschaftswissenschaften & Statistik (LMU);Ludwigstr. 28/I VG;;U3/U6 Universität;Mo-Fr 8-22, Sa, So 9-18;TU-Ausweis bei Zentralbibliothek LMU,\nGeschwister-Scholl-Platz 1, Mo-Fr 9-17;http://www.ub.uni-muenchen.de/bibliotheken/bibs-a-bis-z/0500/index.html
 1014;library;Mathematik & Physik (LMU);Theresienstraße 37;;U3-6 Odeonsplatz;Mo-Fr 8-22, Sa 9-18;TU-Ausweis bei Zentralbibliothek LMU,\nGeschwister-Scholl-Platz 1, Mo-Fr 9-17;http://www.ub.uni-muenchen.de/bibliotheken/bibs-a-bis-z/1600/index.html
-422;cafeteria_gar;Mensa Garching;Lichtenbergstr. 2, Garching;;;Mo-Do 11-14, Fr 11-13.45;;http://www.studentenwerk-muenchen.de/mensa/standorte-und-oeffnungszeiten/garching/#c1430
+422;cafeteria_gar;Mensa Garching;Lichtenbergstr. 2, Garching;;;Mo-Do 11-16, Fr 11-13.45;;http://www.studentenwerk-muenchen.de/mensa/standorte-und-oeffnungszeiten/garching/#c1430
 524;cafeteria_gar;StuCafé Mensa Garching;Lichtenbergstr. 2, Garching;;;Mo-Fr 11-14;;http://www.studentenwerk-muenchen.de/mensa/standorte-und-oeffnungszeiten/garching/#c1432
 527;cafeteria_gar;StuCafé Boltzmannstraße;Boltzmannstr. 15, Garching;;;Mo-Do 10.30-14.30, Fr 10.30-13.45;;http://www.studentenwerk-muenchen.de/mensa/standorte-und-oeffnungszeiten/garching/#c1434
 1015;cafeteria_gar;Espresso-Bar Mensa Garching;Lichtenbergstr. 2, Garching;;;Mo-Do 11-14, Fr 11-13.30;;http://www.studentenwerk-muenchen.de/mensa/standorte-und-oeffnungszeiten/garching/#c1433


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
Mensa Garching has opened until 16:00, see [here](https://www.studentenwerk-muenchen.de/mensa/standorte-und-oeffnungszeiten/garching/).